### PR TITLE
fix: fix memory leak by wrapping listener setup in pcall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azul",
-  "version": "1.0.0",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azul",
-      "version": "1.0.0",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/plugin/Actor/AzulSync.server.luau
+++ b/plugin/Actor/AzulSync.server.luau
@@ -665,17 +665,23 @@ local function startSync()
 
 	-- Defer listener setup to avoid blocking
 	task.defer(function()
-		-- Setup listeners for existing instances
-		local function setupListeners(parent)
-			for _, child in ipairs(parent:GetChildren()) do
-				attachListeners(child)
-				setupListeners(child)
+		local ok, err = pcall(function()
+			-- Setup listeners for existing instances
+			local function setupListeners(parent)
+				for _, child in ipairs(parent:GetChildren()) do
+					attachListeners(child)
+					setupListeners(child)
+				end
 			end
-		end
 
-		for _, service in ipairs(game:GetChildren()) do
-			setupListeners(service)
-			task.wait() -- Yield between services
+			for _, service in ipairs(game:GetChildren()) do
+				setupListeners(service)
+				task.wait() -- Yield between services
+			end
+		end)
+		if not ok then
+			warn("[Azul]: Error during listener setup:", err)
+			stopSync()
 		end
 	end)
 


### PR DESCRIPTION
Wrap listener setup in a pcall to prevent sync from breaking if an error occurs while attaching listeners.