### PR TITLE
Daemon 1.3.5 & Plugin v41

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ _Yes, the name is a pun on Rojo (Spanish for "red"). Azul means "blue"!_
 
 Azul treats **Studio as the source of truth**. The local filesystem mirrors what's in Studio, not the other way around.
 
-Azul avoids the complexity and ambiguity that can come with tools like Rojo: for example, deciding a new Script's parent class, properties, or attributes. Rather than trying to encode Studio state in extra files (e.g. `*.meta.json`), Azul lets Studio be the source of truth. This, in my opinion, leads to a much simpler and more intuitive workflow.
+It avoids the complexity and ambiguity that can come with tools like Rojo: for example, deciding a new Script's parent class, properties, or attributes. Rather than trying to encode Studio state in extra files (i.e. `model.json`, `meta.json`...), Azul lets Studio determine state. This leads to a much simpler and more intuitive workflow.
 
-Azul also allows pushing local files into Studio using the `azul build` command, which creates or overwrites instances in Studio based on your local files.
+While Azul mainly follows this philosophy, it doesn't cut you off from the filesystem. Build from local files using the `azul build` command, or selectively push files using `azul push`.
 
 ## Features
 
 - - [x] 🔄 **Bi-directional sync**: Changes in Studio update files, and file edits update Studio
-- - [x] 🏗️ **[Build command](https://azul-docs.vercel.app/getting-started/projects/#build-from-an-existing-local-project)**: `azul build` one-time pushes your local files into Studio (creates or overwrites, never deletes)
-- - [x] 📦 **[Push command](https://azul-docs.vercel.app/commands/#azul-push)**: `azul push` selectively pushes local files. Useful when importing external libraries or using package managers (i.e Wally)
-- - [x] 🏛️ **Fully hermetic builds**: Use [`azul pack`](https://azul-docs.vercel.app/commands/#azul-pack) to fully serialize Instance properties, allowing for 1:1 reproductible builds when `build`ing or `push`ing.
-- - [x] 🔴 **Rojo compatibility mode**: Supports importing from Rojo projects with the `--rojo` flag.
 - - [x] 🌳 **DataModel mirroring**: Instance hierarchy 1:1 mapped to folder structure
-- - [x] 🎯 **No manual config / required structure**: Works out of the box with new and existing Roblox Studio projects, regardless of structure.
+- - [x] 🎯 **No manual config / required structure**: Works out of the box with new and existing Roblox Studio projects, regardless of structure
+- - [x] 🏗️ **[Build command](https://azul-docs.vercel.app/getting-started/projects/#build-from-an-existing-local-project)**: Sync your local files into Studio with `azul build`.
+- - [x] 📦 **[Push command](https://azul-docs.vercel.app/commands/#azul-push)**: Selectively push local files into Studio using `azul push`. Useful when importing external libraries or using package managers (i.e Wally)
+- - [x] 🏛️ **[Fully hermetic builds](https://azul-docs.vercel.app/commands/#azul-pack)**: Fully serialize Instance properties using `azul pack`, allowing for clean, reproductible builds when `build`ing or `push`ing.
+- - [x] 🔴 **Rojo compatibility mode**: Supports importing from Rojo projects with the `--rojo` flag.
 - - [x] 🗺️ **Automatic sourcemap generation**: Generates a Rojo-compatible `sourcemap.json` so tools like Luau-lsp work out of the box.
 
 ## Why Azul?
@@ -37,7 +37,7 @@ Compatible with projects both old and new, no more extra worrying about how to �
 
 While Rojo is a powerful tool, I don't believe it's always the best fit for every developer or project. Otherwise trivial tasks in Studio, like inserting a Script inside Tool or Model, suddenly become non-trivial challenges. Rojo just lacks the flexibility of Studio.
 
-Azul is my approach to solve these issues. I built Azul for workflows similar to mine: Studio-first developers who'd rather manage their projects in the dedicated environment instead of fighting with meta files.
+Azul is my approach to solve these issues. I built Azul for workflows similar to mine: Studio-first developers who'd rather manage their projects in the dedicated environment instead of fighting with project files.
 
 ### Why not use the upcoming Script Sync feature?
 
@@ -49,7 +49,7 @@ Azul offers several advantages over the upcoming Script Sync feature:
 
 - **Pushing from filesystem**: Sync any code you have stored locally directly to your desired destination using `azul push`. Useful when importing external libraries (e.g. GitHub) or when using Package Managers (e.g. Wally, pesde)
 
-- **Rojo compatibility**: Azul can import existing Rojo projects using the `--rojo` & `--rojo-project=<ProjectFile>` flags, making Azul compatible with many existing open source projects.
+- **Rojo compatibility**: Azul can import existing Rojo projects using the `--rojo` & `--rojo-project <file>` flags, making Azul compatible with many existing open source projects.
   - **Generates a Rojo-compatible `sourcemap.json`**: This allows any tooling that require Rojo-style sourcemaps _(like luau-lsp, the language server)_ to work seamlessly.
 
 - **You can use it today!**: Azul requires no commitment to a specific project structure. If you want to try out Script Sync (or any other tool) in the future, Azul won't get in your way.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Azul allows you to use professional-grade tools like Visual Studio Code in Roblo
 
 _Yes, the name is a pun on Rojo (Spanish for "red"). Azul means "blue"!_
 
-<a href="#quick-start"><b>Quick Start</b></a> — <a href="#why-azul"><b>Why Azul</b></a> — <a href="https://github.com/Ransomwave/azul/wiki"><b>Documentation</b></a>
+<a href="#quick-start"><b>Quick Start</b></a> — <a href="#why-azul"><b>Why Azul</b></a> — <a href="https://azul-docs.vercel.app"><b>Documentation</b></a>
 
 ## Philosophy
 
@@ -19,9 +19,9 @@ Azul also allows pushing local files into Studio using the `azul build` command,
 ## Features
 
 - - [x] 🔄 **Bi-directional sync**: Changes in Studio update files, and file edits update Studio
-- - [x] 🏗️ **[Build command](https://github.com/Ransomwave/azul/wiki/Getting-started#building-from-an-existing-project)**: `azul build` one-time pushes your local files into Studio (creates or overwrites, never deletes)
-- - [x] 📦 **[Push command](https://github.com/Ransomwave/azul/wiki/Commands#azul-push)**: `azul push` selectively pushes local files. Useful when importing external libraries or using package managers (i.e Wally)
-- - [x] 🏛️ **Fully hermetic builds**: Use [`azul pack`](https://github.com/Ransomwave/azul/wiki/Commands#azul-pack) to fully serialize Instance properties, allowing for 1:1 reproductible builds when `build`ing or `push`ing.
+- - [x] 🏗️ **[Build command](https://azul-docs.vercel.app/getting-started/projects/#build-from-an-existing-local-project)**: `azul build` one-time pushes your local files into Studio (creates or overwrites, never deletes)
+- - [x] 📦 **[Push command](https://azul-docs.vercel.app/commands/#azul-push)**: `azul push` selectively pushes local files. Useful when importing external libraries or using package managers (i.e Wally)
+- - [x] 🏛️ **Fully hermetic builds**: Use [`azul pack`](https://azul-docs.vercel.app/commands/#azul-pack) to fully serialize Instance properties, allowing for 1:1 reproductible builds when `build`ing or `push`ing.
 - - [x] 🔴 **Rojo compatibility mode**: Supports importing from Rojo projects with the `--rojo` flag.
 - - [x] 🌳 **DataModel mirroring**: Instance hierarchy 1:1 mapped to folder structure
 - - [x] 🎯 **No manual config / required structure**: Works out of the box with new and existing Roblox Studio projects, regardless of structure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azul-sync",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azul-sync",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azul-sync",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Azul is an easy but powerful Studio-first, two-way synchronization tool for Roblox development. Edit your Roblox projects using your favorite IDE, while keeping everything in sync with Roblox Studio in real-time.",
   "main": "dist/index.js",
   "type": "module",

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Actor/AzulSync.server.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Actor/AzulSync.server.luau
@@ -524,7 +524,45 @@ end
 local function wipeChildren(container: Instance)
 	for _, child in ipairs(container:GetChildren()) do
 		if AzulService.isProtectedRobloxContainer(child) then continue end
-		child:Destroy()
+		local ok, err = pcall(function()
+			child:Destroy()
+		end)
+		if not ok then warn(`[Azul]: Cannot destroy '{child.Name}': {err}`) end
+	end
+end
+
+local function wipeBuildRoots(instances: { any })
+	local rootsSeen = {}
+
+	-- Collect root containers to wipe (optimize by avoiding redundant wipes on shared ancestors)
+	for _, item in ipairs(instances) do
+		local path = item.path
+		if type(path) == "table" and #path >= 1 then
+			local rootName = path[1]
+			if type(rootName) == "string" and rootName ~= "" then rootsSeen[rootName] = true end
+		end
+	end
+
+	for rootName in pairs(rootsSeen) do
+		local rootInstance: Instance? = nil
+
+		local okService, service = pcall(function()
+			return game:GetService(rootName)
+		end)
+		if okService and service then
+			rootInstance = service
+		else
+			rootInstance = game:FindFirstChild(rootName)
+		end
+
+		if rootInstance then
+			local ok, err = pcall(function()
+				wipeChildren(rootInstance)
+			end)
+			if not ok then warn(`[Azul]: Failed to wipe children for root container '{rootName}': {err}`) end
+		else
+			warn(`[Azul]: Destructive build could not find root container '{rootName}', skipping wipe`)
+		end
 	end
 end
 
@@ -638,6 +676,8 @@ local function processMessage(message)
 		setOutboundSuppressed(true)
 
 		local ok, err = pcall(function()
+			if message.destructive == true then wipeBuildRoots(message.data or {}) end
+
 			local created, updated, appliedGuidMap = AzulService.applySnapshotInstances(message.data)
 			-- Update tracking with new instances
 			for guid, instance in pairs(appliedGuidMap) do

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Actor/AzulSync.server.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Actor/AzulSync.server.luau
@@ -690,6 +690,9 @@ local function processMessage(message)
 		end)
 	elseif message.type == "requestPushConfig" then
 		sendDaemonConfig(true)
+	elseif message.type == "daemonDisconnect" then
+		infoPrint("Daemon is shutting down; disconnecting plugin")
+		stopSync(true)
 	elseif message.type == "error" then
 		warn("[Azul]: Daemon error:", message.message)
 	elseif message.type == "pong" then
@@ -792,7 +795,11 @@ local function startSync()
 			-- Send heartbeat periodically
 			local now = os.time()
 			if now - lastHeartbeat > safeGetNumber(CONFIG.HEARTBEAT_INTERVAL, 30) then
-				sendMessage("ping", {})
+				if not sendMessage("ping", {}) then
+					warn("[Azul]: Lost connection to daemon")
+					stopSync()
+					return
+				end
 				lastHeartbeat = now
 			end
 
@@ -814,10 +821,10 @@ local function startSync()
 end
 
 -- Stop sync
-function stopSync()
+function stopSync(dontRelayDisconnect: boolean?)
 	if not syncEnabled then return end
 
-	sendMessage("clientDisconnect", {})
+	if not dontRelayDisconnect then sendMessage("clientDisconnect", {}) end
 
 	infoPrint("Stopping sync...")
 	syncEnabled = false

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -305,12 +305,11 @@ function AzulService.applySnapshotInstances(instances: { InstanceData }): (numbe
 		local protectedContainerName: string? = nil
 		local first = adjustedPath[1]
 		local maybeParent = lockedContainerParentsMap[first]
-		if maybeParent and maybeParent ~= first then
-			table.insert(adjustedPath, 1, maybeParent)
-			protectedContainerName = adjustedPath[2]
-		end
+		if maybeParent and maybeParent ~= first then table.insert(adjustedPath, 1, maybeParent) end
 
-		if not protectedContainerName and #adjustedPath >= 2 then
+		-- Only treat as a protected-container target when the path points to the
+		-- container itself (StarterPlayer/<LockedContainer>), not its descendants.
+		if #adjustedPath == 2 then
 			local second = adjustedPath[2]
 			if lockedContainerParentsMap[second] == adjustedPath[1] then protectedContainerName = second end
 		end
@@ -521,8 +520,14 @@ function AzulService.applySnapshotInstances(instances: { InstanceData }): (numbe
 		end
 
 		if isScriptClass(item.className) and item.source and instance then
-			AzulService.setScriptSource(instance :: Script, item.source)
-			updated += 1
+			if isScript(instance) then
+				AzulService.setScriptSource(instance :: Script, item.source)
+				updated += 1
+			else
+				debugPrint(
+					`Skipped source apply for non-script instance "{instance.Name}" ({instance.ClassName}) targeting class "{item.className}".`
+				)
+			end
 		end
 	end
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -1,6 +1,6 @@
 --!strict
 local AzulService = {}
-AzulService.VERSION = 40
+AzulService.VERSION = 41
 
 -- Services
 local ScriptEditorService = game:GetService("ScriptEditorService")

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -605,6 +605,9 @@ function AzulService.readPushConfig(pushConfigPath: { string }): ({ [string]: an
 						destination = dest,
 						destructive = entry.destructive == true,
 						rojoMode = entry.rojoMode == true,
+						fromSourcemap = if type(entry.fromSourcemap) == "string" and entry.fromSourcemap ~= ""
+							then entry.fromSourcemap
+							else nil,
 					})
 				end
 			end

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/UI.luau
@@ -159,7 +159,15 @@ function UI.new(plugin, callbacks, settingsScope, helpers): SelfType
 	self.connectButton = toolbar:CreateButton("Azul", "Connect/disconnect from sync daemon", self.LOGO)
 
 	-- Create widget
-	local widgetInfo = DockWidgetPluginGuiInfo.new(Enum.InitialDockState.Float, true, true, 345, 640, 300, 300)
+	local widgetInfo = DockWidgetPluginGuiInfo.new(
+		Enum.InitialDockState.Float, -- Widget starts floating
+		true, -- Widget will be initially enabled
+		false, -- Don't override the previous enabled state
+		345, -- Default width
+		640, -- Default height
+		300, -- Minimum width of the floating window (optional)
+		300 -- Minimum height of the floating window (optional)
+	)
 
 	local azulWidget = plugin:CreateDockWidgetPluginGuiAsync("azulWidget", widgetInfo)
 	azulWidget.Name = "AzulCompanionPlugin"

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/WebSocketClient.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/WebSocketClient.luau
@@ -95,7 +95,10 @@ function WebSocketClient:connect()
 		local parseSuccess, parseError = pcall(function()
 			self:handleMessage(message)
 		end)
-		if not parseSuccess then warn("[WebSocket]: Error handling message:", parseError) end
+		if not parseSuccess then
+			warn("[WebSocket]: Error handling message:", parseError)
+			warn("[WebSocket]: Raw message was:", message)
+		end
 	end)
 
 	-- Notify connection established

--- a/src/build.ts
+++ b/src/build.ts
@@ -16,8 +16,9 @@ interface BuildOptions {
   syncDir?: string;
   rojoMode?: boolean;
   rojoProjectFile?: string;
-  applySourcemap?: boolean;
-  fromSourcemap?: boolean;
+  applySourcemapProperties?: boolean;
+  useSourcemapAsSource?: boolean;
+  sourcemapPath?: string;
 }
 
 export class BuildCommand {
@@ -25,15 +26,19 @@ export class BuildCommand {
   private syncDir: string;
   private rojoMode: boolean;
   private rojoProjectFile?: string;
-  private applySourcemap: boolean;
-  private fromSourcemap: boolean;
+  private applySourcemapProperties: boolean;
+  private useSourcemapAsSource: boolean;
+  private sourcemapPath: string;
 
   constructor(options: BuildOptions = {}) {
     this.syncDir = path.resolve(options.syncDir ?? config.syncDir);
     this.rojoMode = Boolean(options.rojoMode);
     this.rojoProjectFile = options.rojoProjectFile;
-    this.applySourcemap = options.applySourcemap !== false;
-    this.fromSourcemap = options.fromSourcemap === true;
+    this.applySourcemapProperties = options.applySourcemapProperties !== false;
+    this.useSourcemapAsSource = options.useSourcemapAsSource === true;
+    this.sourcemapPath = path.resolve(
+      options.sourcemapPath ?? config.sourcemapPath,
+    );
     this.ipc = new IPCServer(config.port, undefined, {
       requestSnapshotOnConnect: false,
     });
@@ -63,8 +68,8 @@ export class BuildCommand {
     }
     let instances: InstanceData[] = [];
 
-    if (!this.rojoMode && this.fromSourcemap) {
-      const built = buildInstancesFromSourcemap(config.sourcemapPath);
+    if (!this.rojoMode && this.useSourcemapAsSource) {
+      const built = buildInstancesFromSourcemap(this.sourcemapPath);
       if (!built) {
         log.warn(
           "Falling back to filesystem build because sourcemap import failed.",
@@ -83,15 +88,19 @@ export class BuildCommand {
       }
     }
 
-    if (!this.rojoMode && this.applySourcemap && !this.fromSourcemap) {
-      const index = loadSourcemapPropertyIndex(config.sourcemapPath);
+    if (
+      !this.rojoMode &&
+      this.applySourcemapProperties &&
+      !this.useSourcemapAsSource
+    ) {
+      const index = loadSourcemapPropertyIndex(this.sourcemapPath);
       const applied = applySourcemapProperties(instances, index);
       if (applied > 0) {
         log.success(
           `Applied properties/attributes from sourcemap to ${applied} instance(s)`,
         );
       } else {
-        if (!index && fs.existsSync(config.sourcemapPath)) {
+        if (!index && fs.existsSync(this.sourcemapPath)) {
           log.warn(
             "Sourcemap present but could not be parsed; continuing without properties.",
           );

--- a/src/build.ts
+++ b/src/build.ts
@@ -19,6 +19,7 @@ interface BuildOptions {
   applySourcemapProperties?: boolean;
   useSourcemapAsSource?: boolean;
   sourcemapPath?: string;
+  destructive?: boolean;
 }
 
 export class BuildCommand {
@@ -29,6 +30,7 @@ export class BuildCommand {
   private applySourcemapProperties: boolean;
   private useSourcemapAsSource: boolean;
   private sourcemapPath: string;
+  private destructive: boolean;
 
   constructor(options: BuildOptions = {}) {
     this.syncDir = path.resolve(options.syncDir ?? config.syncDir);
@@ -39,6 +41,7 @@ export class BuildCommand {
     this.sourcemapPath = path.resolve(
       options.sourcemapPath ?? config.sourcemapPath,
     );
+    this.destructive = options.destructive === true;
     this.ipc = new IPCServer(config.port, undefined, {
       requestSnapshotOnConnect: false,
     });
@@ -117,7 +120,11 @@ export class BuildCommand {
     await new Promise<void>((resolve) => {
       this.ipc.onConnection(() => {
         log.info("Studio connected. Sending build snapshot...");
-        this.ipc.send({ type: "buildSnapshot", data: instances });
+        this.ipc.send({
+          type: "buildSnapshot",
+          data: instances,
+          destructive: this.destructive,
+        });
         log.success(`Sent ${instances.length} instances`);
         setTimeout(() => {
           this.ipc.close();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,46 +30,43 @@ if (parsedArgs.help) {
   console.log(`
 Usage:
   azul <command> [options]
-  azul build [--from-sourcemap <file>] [--rojo] [--rojo-project <file>]
-  azul push [options] [--rojo] [--rojo-project <file>] [--from-sourcemap <file>]
-  azul pack [-o <file>] [--scripts-only]
-  azul config [--path]
 
 Commands:
-  (no command)            Start live sync daemon
-  build                   One-time push from filesystem into Studio
-  push                    Selective push using mappings (place config or -s/-d)
-  pack                    Serialize Studio instance properties into sourcemap.json
-  config                  Open the Azul config file in your default editor
+  (no command)              Start live sync daemon
+  build                     One-time push from filesystem into Studio
+  push                      Selective push using mappings (place config or -s/-d)
+  pack                      Serialize Studio instance properties into sourcemap.json
+  config                    Open the Azul config file in your default editor
 
 Global Options:
-  -h, --help              Show this help message
-  --version               Show Azul version
-  --debug                 Print verbose debug output
-  --no-warn               Disable confirmation prompts for dangerous operations
-  --sync-dir [PATH]       Directory to sync (default: current directory)
-  --port [NUMBER]         Studio connection port
+  -h, --help                Show this help message
+  --version                 Show Azul version
+  --debug                   Print verbose debug output
+  --no-warn                 Disable confirmation prompts for dangerous operations
+  --sync-dir <path>         Directory to sync (default: current directory)
+  --port <number>           Studio connection port
 
 Build Options:
-  --from-sourcemap [FILE] Build from sourcemap
-  --rojo                  Enable Rojo-compatible parsing
-  --rojo-project [FILE]   Use a Rojo project file
+  --from-sourcemap <file>   Build from sourcemap
+  --destructive             Wipe destination children for build roots before applying snapshot
+  --rojo                    Enable Rojo-compatible parsing
+  --rojo-project <file>     Use a Rojo project file
 
 Push Options:
-  -s, --source [DIR]      Source folder to push
-  -d, --destination [PATH] Studio destination path (i.e "ReplicatedStorage.Packages")
-  --from-sourcemap [FILE] Push from sourcemap
-  --no-place-config       Ignore push mappings from place ModuleScript
-  --destructive           Wipe destination children before pushing
-  --rojo                  Enable Rojo-compatible parsing
-  --rojo-project [FILE]   Use a Rojo project file
+  -s, --source <dir>        Source folder to push
+  -d, --destination <path>  Studio destination path (i.e "ReplicatedStorage.Packages")
+  --from-sourcemap <file>   Push from sourcemap
+  --no-place-config         Ignore push mappings from place ModuleScript
+  --destructive             Wipe destination children before pushing
+  --rojo                    Enable Rojo-compatible parsing
+  --rojo-project <file>     Use a Rojo project file
 
 Pack Options:
-  -o, --output            Sourcemap path to write (default: config.sourcemapPath)
-  --scripts-only          Serialize only scripts and their descendants
+  -o, --output <file>       Sourcemap path to write (default: config.sourcemapPath)
+  --scripts-only            Serialize only scripts and their descendants
 
 Config Options:
-  --path                  Print config file path
+  --path                    Print config file path
   `);
   process.exit(0);
 }
@@ -153,9 +150,13 @@ if (parsedArgs.command === "build") {
     parsedArgs.rojo ||
     Boolean(parsedArgs.rojoProject) ||
     parsedArgs.fromSourcemap !== undefined;
+  // || parsedArgs.destructive;
+  // Don't consider passing "--destructive" as enough to bypass interactive mode,
+  // since destructive building without a sourcemap is very likely a mistake.
 
   let applySourcemapProperties = true;
   let useSourcemapAsSource = parsedArgs.fromSourcemap !== undefined;
+  let interactiveDestructive = parsedArgs.destructive;
 
   if (!hasBuildSpecificOptions) {
     const sourcemapExists = fs.existsSync(config.sourcemapPath);
@@ -179,12 +180,28 @@ if (parsedArgs.command === "build") {
         `No sourcemap found at ${config.sourcemapPath}. Build will recreate instances as scripts/folders.`,
       );
     }
+
+    // Only ask about destructive option if we're building from sourcemap.
+    // Destructively building without a sourcemap is very likely a mistake, since it wipes everything in Studio instead of building "on top".
+    // This functionality is still possible with the "--destructive" flag if someone really wants it
+    if (useSourcemapAsSource || applySourcemapProperties) {
+      log.userInput(
+        "Destructive build (wipe everything in Studio & build from scratch)? (Y/N)",
+      );
+      interactiveDestructive = await promptYesNo();
+    }
   }
 
   if (!parsedArgs.noWarn) {
-    log.warn(
-      "WARNING: Building will overwrite matching Studio scripts and create new ones from your local environment. Existing Studio instances will not be deleted. Proceed with caution!",
-    );
+    if (interactiveDestructive) {
+      log.warn(
+        "CAUTION: This will replace your entire Studio state with your local project (all instances, scripts, and properties). Unsaved Studio work WILL BE LOST.",
+      );
+    } else {
+      log.warn(
+        "CAUTION: This will overwrite matching Studio scripts/instances and create new ones from your local project. Instances with no local equivalent will be left untouched.",
+      );
+    }
     log.userInput("Continue with build? (Y/N)");
 
     await new Promise<void>((resolve) => {
@@ -218,6 +235,7 @@ if (parsedArgs.command === "build") {
     applySourcemapProperties,
     useSourcemapAsSource,
     sourcemapPath: parsedArgs.fromSourcemap,
+    destructive: interactiveDestructive,
   }).run();
 
   log.info("Build command completed.");
@@ -312,7 +330,7 @@ if (parsedArgs.command === "push") {
 
   if (parsedArgs.destructive && !parsedArgs.noWarn) {
     log.warn(
-      "WARNING: Destructive push will wipe destination children before applying snapshot. Proceed? (Y/N)",
+      "CAUTION: Destructive push will wipe destination children before applying snapshot. Proceed? (Y/N)",
     );
 
     await new Promise<void>((resolve) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -377,7 +377,34 @@ if (command === "pack") {
   process.exit(0);
 }
 
-new SyncDaemon().start();
+const liveDaemon = new SyncDaemon();
+liveDaemon.start();
+
+let liveDaemonStopping = false;
+const stopLiveDaemon = async (signal: string): Promise<void> => {
+  if (liveDaemonStopping) {
+    return;
+  }
+
+  liveDaemonStopping = true;
+  log.info(`Received ${signal}, shutting down...`);
+
+  try {
+    await liveDaemon.stop();
+    process.exit(0);
+  } catch (error) {
+    log.error(`Failed to stop daemon cleanly: ${error}`);
+    process.exit(1);
+  }
+};
+
+process.on("SIGINT", () => {
+  void stopLiveDaemon("SIGINT");
+});
+
+process.on("SIGTERM", () => {
+  void stopLiveDaemon("SIGTERM");
+});
 
 function getFlagValue(flags: string[], argv: string[]): string | null {
   for (let i = 0; i < argv.length; i++) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { BuildCommand } from "./build.js";
 import { PushCommand } from "./push.js";
 import { PackCommand } from "./pack.js";
 import { fileURLToPath } from "node:url";
+import { parseCliArgs } from "./util/cliArgs.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
@@ -17,20 +18,15 @@ const pkg = JSON.parse(
 );
 const { version } = pkg;
 
-const args = process.argv.slice(2);
-const commandIndex = args.findIndex((a) => !a.startsWith("--"));
-const command = commandIndex >= 0 ? args[commandIndex] : null;
-const syncDirFlag = args.find((a) => a.startsWith("--sync-dir="));
-const portFlag = args.find((a) => a.startsWith("--port="));
-const debugFlag = args.find((a) => a === "--debug");
-const noWarnFlag = args.find((a) => a === "--no-warn");
-const rojoFlag = args.includes("--rojo");
-const rojoProjectFlag = getFlagValue(["--rojo-project"], args);
-const fromSourcemapValue = getFlagValue(["--from-sourcemap"], args);
-const fromSourcemapFlag =
-  args.includes("--from-sourcemap") || fromSourcemapValue !== null;
+let parsedArgs;
+try {
+  parsedArgs = parseCliArgs(process.argv.slice(2));
+} catch (error) {
+  log.error(`${error}`);
+  process.exit(1);
+}
 
-if (args.includes("--help") || args.includes("-h")) {
+if (parsedArgs.help) {
   console.log(`
 Usage:
   azul <command> [options]
@@ -78,7 +74,7 @@ Config Options:
   process.exit(0);
 }
 
-if (args.includes("--version")) {
+if (parsedArgs.version) {
   log.info(`Azul version: ${version}`);
   process.exit(0);
 }
@@ -86,10 +82,10 @@ if (args.includes("--version")) {
 initializeConfig();
 log.debug(`Loaded user config from: ${getUserConfigPath()}`);
 
-if (command === "config") {
+if (parsedArgs.command === "config") {
   const userConfigPath = getUserConfigPath();
 
-  if (args.includes("--path")) {
+  if (parsedArgs.configPath) {
     console.log(userConfigPath);
     process.exit(0);
   }
@@ -98,8 +94,7 @@ if (command === "config") {
     await openWithDefaultEditor(userConfigPath);
     log.info(`Opened Azul config: ${userConfigPath}`);
   } catch (error) {
-    log.error(`Failed to open config file: ${error}`);
-    process.exit(1);
+    throw new Error(`Failed to open config file: ${error}`);
   }
 
   process.exit(0);
@@ -110,10 +105,10 @@ const currentPath = process.cwd();
 if (
   (currentPath.includes(`\\${config.syncDir}`) ||
     currentPath.includes(`/${config.syncDir}`)) &&
-  !noWarnFlag
+  !parsedArgs.noWarn
 ) {
   log.warn(
-    `Looks like you're trying to run Azul from within a '${config.syncDir}' directory. Continuing to run Azul will create a directory like "/${config.syncDir}/${config.syncDir}/".`,
+    `Looks like you're trying to run Azul from within a '${config.syncDir}' directory. Running Azul here will create a directory like "/${config.syncDir}/${config.syncDir}/", which may be unintended.`,
   );
   log.userInput("Continue? (Y/N)");
 
@@ -141,23 +136,26 @@ if (
 
 log.info(`Running azul from: ${currentPath}`);
 
-if (syncDirFlag) config.syncDir = resolve(syncDirFlag.split("=")[1]);
-if (portFlag) config.port = Number(portFlag.split("=")[1]);
-if (debugFlag) config.debugMode = true;
+if (parsedArgs.syncDir) config.syncDir = resolve(parsedArgs.syncDir);
+if (parsedArgs.port) config.port = parsedArgs.port;
+if (parsedArgs.debug) config.debugMode = true;
 
 log.debug(`Debug mode is on!`);
 
-if (command === "build") {
-  if (!rojoFlag && fs.existsSync("default.project.json")) {
+if (parsedArgs.command === "build") {
+  if (!parsedArgs.rojo && fs.existsSync("default.project.json")) {
     log.warn(
-      'Detected default.project.json! You can enable Rojo compatibility mode by passing the "--rojo" flag.',
+      'Detected a default.project.json file! You can enable Rojo compatibility mode by passing the "--rojo" flag.',
     );
   }
 
   const hasBuildSpecificOptions =
-    rojoFlag || Boolean(rojoProjectFlag) || fromSourcemapFlag;
-  let applySourcemap = !fromSourcemapFlag;
-  let fromSourcemap = fromSourcemapFlag;
+    parsedArgs.rojo ||
+    Boolean(parsedArgs.rojoProject) ||
+    parsedArgs.fromSourcemap !== undefined;
+
+  let applySourcemapProperties = true;
+  let useSourcemapAsSource = parsedArgs.fromSourcemap !== undefined;
 
   if (!hasBuildSpecificOptions) {
     const sourcemapExists = fs.existsSync(config.sourcemapPath);
@@ -167,23 +165,23 @@ if (command === "build") {
       );
       const useFull = await promptYesNo();
       if (useFull) {
-        fromSourcemap = true;
-        applySourcemap = false;
+        useSourcemapAsSource = true;
+        applySourcemapProperties = false;
       } else {
         log.userInput(
           `Use packed properties/attributes from ${config.sourcemapPath}? (Y/N)`,
         );
-        applySourcemap = await promptYesNo();
+        applySourcemapProperties = await promptYesNo();
       }
     } else {
-      applySourcemap = false;
+      applySourcemapProperties = false;
       log.info(
         `No sourcemap found at ${config.sourcemapPath}. Build will recreate instances as scripts/folders.`,
       );
     }
   }
 
-  if (!noWarnFlag) {
+  if (!parsedArgs.noWarn) {
     log.warn(
       "WARNING: Building will overwrite matching Studio scripts and create new ones from your local environment. Existing Studio instances will not be deleted. Proceed with caution!",
     );
@@ -215,10 +213,11 @@ if (command === "build") {
 
   await new BuildCommand({
     syncDir: config.syncDir,
-    rojoMode: rojoFlag,
-    rojoProjectFile: rojoProjectFlag ?? undefined,
-    applySourcemap,
-    fromSourcemap,
+    rojoMode: parsedArgs.rojo,
+    rojoProjectFile: parsedArgs.rojoProject ?? undefined,
+    applySourcemapProperties,
+    useSourcemapAsSource,
+    sourcemapPath: parsedArgs.fromSourcemap,
   }).run();
 
   log.info("Build command completed.");
@@ -228,30 +227,29 @@ if (command === "build") {
   process.exit(0);
 }
 
-if (command === "push") {
-  const sourceValue = getFlagValue(["-s", "--source"], args);
-  const destValue = getFlagValue(["-d", "--destination"], args);
-  const destructive = args.includes("--destructive");
-  const usePlaceConfig = !args.includes("--no-place-config");
+if (parsedArgs.command === "push") {
+  const usePlaceConfig = !parsedArgs.noPlaceConfig;
 
   const hasPushSpecificOptions = Boolean(
-    sourceValue ||
-    destValue ||
-    destructive ||
+    parsedArgs.source ||
+    parsedArgs.destination ||
+    parsedArgs.destructive ||
     !usePlaceConfig ||
-    rojoFlag ||
-    rojoProjectFlag ||
-    fromSourcemapFlag,
+    parsedArgs.rojo ||
+    parsedArgs.rojoProject ||
+    parsedArgs.fromSourcemap,
   );
 
-  let interactiveSource = sourceValue ?? undefined;
-  let interactiveDest = destValue ?? undefined;
-  let interactiveDestructive = destructive;
+  let interactiveSource = parsedArgs.source ?? undefined;
+  let interactiveDest = parsedArgs.destination ?? undefined;
+  let interactiveDestructive = parsedArgs.destructive;
   let interactiveUsePlaceConfig = usePlaceConfig;
-  let applySourcemap = !rojoFlag && !fromSourcemapFlag;
-  let fromSourcemap = !rojoFlag && fromSourcemapFlag;
+  let useSourcemapAsSource =
+    !parsedArgs.rojo && parsedArgs.fromSourcemap !== undefined;
+  let applySourcemapProperties =
+    !parsedArgs.rojo && parsedArgs.fromSourcemap === undefined;
 
-  if (!hasPushSpecificOptions && !rojoFlag) {
+  if (!hasPushSpecificOptions && !parsedArgs.rojo) {
     log.userInput(
       "Use place config from Studio (ServerStorage.Azul.Config)? (Y/N)",
     );
@@ -271,45 +269,48 @@ if (command === "push") {
   }
 
   const willUsePlaceConfig =
-    !rojoFlag &&
+    !parsedArgs.rojo &&
     interactiveUsePlaceConfig &&
     !(interactiveSource && interactiveDest);
 
-  if (!rojoFlag && !fromSourcemapFlag && !willUsePlaceConfig) {
+  if (
+    !parsedArgs.rojo &&
+    parsedArgs.fromSourcemap === undefined &&
+    !willUsePlaceConfig
+  ) {
     log.userInput(
       `Build push snapshot directly from ${config.sourcemapPath} (includes non-script descendants and ancestors)? (Y/N)`,
     );
-    fromSourcemap = await promptYesNo();
-    if (fromSourcemap) {
+    useSourcemapAsSource = await promptYesNo();
+    if (useSourcemapAsSource) {
       if (fs.existsSync(config.sourcemapPath)) {
         log.userInput(
           `Apply packed properties/attributes from ${config.sourcemapPath}? (Y/N)`,
         );
-        applySourcemap = await promptYesNo();
+        applySourcemapProperties = await promptYesNo();
       } else {
-        fromSourcemap = false;
-        applySourcemap = false;
-        log.warn(
-          `No sourcemap found at "${config.sourcemapPath}"! Please create one or provide it using the "--from-sourcemap" flag.`,
+        useSourcemapAsSource = false;
+        applySourcemapProperties = false;
+        throw new Error(
+          `Sourcemap not found at "${config.sourcemapPath}"! Please create one or provide it using the "--from-sourcemap" flag.`,
         );
-        process.exit(1);
       }
     } else {
-      fromSourcemap = false;
-      applySourcemap = false;
+      useSourcemapAsSource = false;
+      applySourcemapProperties = false;
       log.info(
         `Not using sourcemap. Azul will recreate instances as scripts/folders based on your local filesystem structure with default Properties/Attributes.`,
       );
     }
   }
 
-  if (!rojoFlag && fs.existsSync("default.project.json")) {
+  if (!parsedArgs.rojo && fs.existsSync("default.project.json")) {
     log.info(
       "Detected default.project.json. Azul stays in native mode unless you pass --rojo.",
     );
   }
 
-  if (destructive && !noWarnFlag) {
+  if (parsedArgs.destructive && !parsedArgs.noWarn) {
     log.warn(
       "WARNING: Destructive push will wipe destination children before applying snapshot. Proceed? (Y/N)",
     );
@@ -342,15 +343,12 @@ if (command === "push") {
     source: interactiveSource ?? undefined,
     destination: interactiveDest ?? undefined,
     destructive: interactiveDestructive,
-    usePlaceConfig: rojoFlag ? false : interactiveUsePlaceConfig,
-    rojoMode: rojoFlag,
-    rojoProjectFile: rojoProjectFlag ?? undefined,
-    applySourcemap,
-    fromSourcemap,
-    sourcemapPath:
-      fromSourcemapValue && !fromSourcemapValue.startsWith("--")
-        ? fromSourcemapValue
-        : undefined,
+    usePlaceConfig: parsedArgs.rojo ? false : interactiveUsePlaceConfig,
+    rojoMode: parsedArgs.rojo,
+    rojoProjectFile: parsedArgs.rojoProject ?? undefined,
+    applySourcemapProperties,
+    useSourcemapAsSource,
+    sourcemapPath: parsedArgs.fromSourcemap,
   }).run();
 
   log.info("Push command completed.");
@@ -358,14 +356,12 @@ if (command === "push") {
   process.exit(0);
 }
 
-if (command === "pack") {
-  const outputValue = getFlagValue(["-o", "--output"], args);
-  let scriptsOnly = args.includes("--scripts-only");
+if (parsedArgs.command === "pack") {
+  let scriptsOnly = parsedArgs.scriptsOnly;
 
-  const hasPackSpecificOptions =
-    outputValue !== null || args.includes("--scripts-only");
+  const hasPackSpecificOptions = parsedArgs.output !== undefined || scriptsOnly;
 
-  let finalOutputPath = outputValue ?? config.sourcemapPath;
+  let finalOutputPath = parsedArgs.output ?? config.sourcemapPath;
 
   if (!hasPackSpecificOptions) {
     const interactive = await promptPackInteractive(config.sourcemapPath);
@@ -398,8 +394,7 @@ const stopLiveDaemon = async (signal: string): Promise<void> => {
     await liveDaemon.stop();
     process.exit(0);
   } catch (error) {
-    log.error(`Failed to stop daemon cleanly: ${error}`);
-    process.exit(1);
+    throw new Error(`Failed to stop daemon cleanly: ${error}`);
   }
 };
 
@@ -410,21 +405,6 @@ process.on("SIGINT", () => {
 process.on("SIGTERM", () => {
   void stopLiveDaemon("SIGTERM");
 });
-
-function getFlagValue(flags: string[], argv: string[]): string | null {
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    for (const flag of flags) {
-      if (arg === flag) {
-        return argv[i + 1] ?? null;
-      }
-      if (arg.startsWith(`${flag}=`)) {
-        return arg.split("=")[1] ?? null;
-      }
-    }
-  }
-  return null;
-}
 
 function openWithDefaultEditor(targetPath: string): Promise<void> {
   return new Promise((resolvePromise, rejectPromise) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -270,7 +270,12 @@ if (command === "push") {
     }
   }
 
-  if (!rojoFlag && !fromSourcemapFlag) {
+  const willUsePlaceConfig =
+    !rojoFlag &&
+    interactiveUsePlaceConfig &&
+    !(interactiveSource && interactiveDest);
+
+  if (!rojoFlag && !fromSourcemapFlag && !willUsePlaceConfig) {
     log.userInput(
       `Build push snapshot directly from ${config.sourcemapPath} (includes non-script descendants and ancestors)? (Y/N)`,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export class SyncDaemon {
   private sourcemapGenerator: SourcemapGenerator;
   private batchDepth = 0; // Tracks nested batch processing
   private batchNeedsSourcemapRegen = false; // Defer regen until batch ends
+  private stopPromise: Promise<void> | null = null;
 
   constructor() {
     this.tree = new TreeManager();
@@ -99,8 +100,11 @@ export class SyncDaemon {
         break;
 
       case "clientDisconnect":
-        log.info("Studio requested to close the connection");
-        this.ipc.close();
+        log.info("Studio requested daemon shutdown");
+        void (async () => {
+          await this.stop();
+          process.exit(0);
+        })();
         break;
 
       default:
@@ -363,11 +367,29 @@ export class SyncDaemon {
    * Stop the daemon
    */
   public async stop(): Promise<void> {
-    log.info("Stopping daemon...");
-    await this.fileWatcher.stop();
-    this.ipc.close();
-    this.httpServer.close();
-    log.info("Daemon stopped");
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+
+    this.stopPromise = (async () => {
+      log.info("Stopping daemon...");
+      await this.fileWatcher.stop();
+      this.ipc.send({ type: "daemonDisconnect" });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      this.ipc.close();
+      await new Promise<void>((resolve, reject) => {
+        this.httpServer.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+      log.info("Daemon stopped");
+    })();
+
+    return this.stopPromise;
   }
 
   private isScriptClass(className: string): boolean {
@@ -438,6 +460,7 @@ if (isDirectRun) {
   // Handle graceful shutdown
   process.on("SIGINT", async () => {
     console.log("\n");
+    console.log("Received SIGINT, shutting down...");
     await daemon.stop();
     process.exit(0);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,7 @@ export class SyncDaemon {
 
     if (guid) {
       log.info(
-        `File changed externally: ${path.relative(this.fileWriter.getBaseDir(), filePath)}.`,
+        `File changed externally: ${path.relative(this.fileWriter.getBaseDir(), filePath)}`,
       );
 
       // Same-source anti-echo should be handled in watcher.ts, this is just in case

--- a/src/ipc/messages.ts
+++ b/src/ipc/messages.ts
@@ -133,6 +133,7 @@ export interface ErrorMessage {
 export interface BuildSnapshotMessage {
   type: "buildSnapshot";
   data: InstanceData[];
+  destructive?: boolean;
 }
 
 export interface RequestPushConfigMessage {

--- a/src/ipc/messages.ts
+++ b/src/ipc/messages.ts
@@ -162,4 +162,5 @@ export interface PushConfigMapping {
   destination: string[];
   destructive?: boolean;
   rojoMode?: boolean;
+  fromSourcemap?: string;
 }

--- a/src/ipc/messages.ts
+++ b/src/ipc/messages.ts
@@ -100,6 +100,7 @@ export type DaemonMessage =
   | PatchScriptMessage
   | RequestSnapshotMessage
   | PongMessage
+  | DaemonDisconnectMessage
   | ErrorMessage
   | BuildSnapshotMessage
   | RequestPushConfigMessage
@@ -118,6 +119,10 @@ export interface RequestSnapshotMessage {
 
 export interface PongMessage {
   type: "pong";
+}
+
+export interface DaemonDisconnectMessage {
+  type: "daemonDisconnect";
 }
 
 export interface ErrorMessage {

--- a/src/ipc/server.ts
+++ b/src/ipc/server.ts
@@ -16,6 +16,7 @@ export class IPCServer {
   private messageHandler: MessageHandler | null = null;
   private connectionHandler: (() => void) | null = null;
   private requestSnapshotOnConnect: boolean;
+  private pingIntervals = new Map<WebSocket, NodeJS.Timeout>();
 
   constructor(port?: number, server?: HttpServer, options?: IPCServerOptions) {
     this.requestSnapshotOnConnect = options?.requestSnapshotOnConnect !== false;
@@ -69,6 +70,12 @@ export class IPCServer {
       });
 
       ws.on("close", () => {
+        const pingInterval = this.pingIntervals.get(ws);
+        if (pingInterval) {
+          clearInterval(pingInterval);
+          this.pingIntervals.delete(ws);
+        }
+
         log.info("Studio client disconnected");
         this.client = null;
       });
@@ -88,8 +95,10 @@ export class IPCServer {
           ws.ping();
         } else {
           clearInterval(pingInterval);
+          this.pingIntervals.delete(ws);
         }
       }, 30000);
+      this.pingIntervals.set(ws, pingInterval);
 
       // Request initial snapshot after a brief delay
       if (this.requestSnapshotOnConnect) {
@@ -185,12 +194,16 @@ export class IPCServer {
    * Close the server
    */
   public close(): void {
+    for (const interval of this.pingIntervals.values()) {
+      clearInterval(interval);
+    }
+    this.pingIntervals.clear();
+
     if (this.client) {
       this.client.close();
+      this.client = null;
     }
     this.wss.close();
     log.info("WebSocket server closed.");
-    log.info("Exiting...");
-    process.exit(0);
   }
 }

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -36,6 +36,8 @@ interface SourcemapRoot {
   };
 }
 
+const PACK_VERSION = 1;
+
 export class PackCommand {
   private ipc: IPCServer;
   private outputPath: string;
@@ -290,7 +292,7 @@ export class PackCommand {
     }
 
     sourcemap._azul = {
-      packVersion: 1,
+      packVersion: PACK_VERSION,
       packedAt: new Date().toISOString(),
       mode: this.scriptsAndDescendantsOnly ? "scripts-and-descendants" : "all",
     };

--- a/src/push.ts
+++ b/src/push.ts
@@ -39,6 +39,10 @@ export class PushCommand {
   private options: PushOptions;
   private sourcemapPath: string;
   private sourcemapIndex: ReturnType<typeof loadSourcemapPropertyIndex>;
+  private sourcemapIndexByPath: Map<
+    string,
+    ReturnType<typeof loadSourcemapPropertyIndex>
+  >;
 
   constructor(options: PushOptions = {}) {
     this.options = options;
@@ -46,6 +50,9 @@ export class PushCommand {
       options.sourcemapPath ?? config.sourcemapPath,
     );
     this.sourcemapIndex = loadSourcemapPropertyIndex(this.sourcemapPath);
+    this.sourcemapIndexByPath = new Map([
+      [this.sourcemapPath, this.sourcemapIndex],
+    ]);
     this.ipc = new IPCServer(config.port, undefined, {
       requestSnapshotOnConnect: false,
     });
@@ -145,11 +152,18 @@ export class PushCommand {
         skipSymlinks: true,
       });
 
-      const instances = this.options.fromSourcemap
-        ? this.buildPushInstancesFromSourcemap(sourceDir, destSegments)
+      const mappingSourcemapPath = this.resolveMappingSourcemapPath(mapping);
+      const useFromSourcemap = Boolean(mappingSourcemapPath);
+
+      const instances = useFromSourcemap
+        ? this.buildPushInstancesFromSourcemap(
+            sourceDir,
+            destSegments,
+            mappingSourcemapPath!,
+          )
         : await builder.build();
 
-      if (this.options.fromSourcemap && !instances) {
+      if (useFromSourcemap && !instances) {
         log.warn(
           `Could not derive sourcemap subtree for ${sourceDir}; falling back to filesystem snapshot.`,
         );
@@ -169,14 +183,11 @@ export class PushCommand {
         continue;
       }
 
-      if (
-        !this.options.fromSourcemap &&
-        this.options.applySourcemap !== false
-      ) {
-        const applied = applySourcemapProperties(
-          instances,
-          this.sourcemapIndex,
+      if (!useFromSourcemap && this.options.applySourcemap !== false) {
+        const sourcemapIndex = this.getSourcemapIndexForPath(
+          this.sourcemapPath,
         );
+        const applied = applySourcemapProperties(instances, sourcemapIndex);
         if (applied > 0) {
           log.success(
             `Applied properties/attributes from sourcemap to ${applied} instance(s) for ${destSegments.join("/")}`,
@@ -450,6 +461,10 @@ export class PushCommand {
       destination: m.destination,
       destructive: Boolean(m.destructive),
       rojoMode: Boolean(m.rojoMode),
+      fromSourcemap:
+        typeof m.fromSourcemap === "string" && m.fromSourcemap.trim().length > 0
+          ? m.fromSourcemap
+          : undefined,
     }));
   }
 
@@ -463,8 +478,9 @@ export class PushCommand {
   private buildPushInstancesFromSourcemap(
     sourceDir: string,
     destSegments: string[],
+    sourcemapPath: string,
   ): InstanceData[] | null {
-    const all = buildInstancesFromSourcemap(this.sourcemapPath);
+    const all = buildInstancesFromSourcemap(sourcemapPath);
     if (!all || all.length === 0) {
       return null;
     }
@@ -487,6 +503,36 @@ export class PushCommand {
 
     rebased.sort((a, b) => a.path.length - b.path.length);
     return rebased;
+  }
+
+  private resolveMappingSourcemapPath(mapping: {
+    fromSourcemap?: string;
+  }): string | null {
+    if (this.options.fromSourcemap) {
+      return this.sourcemapPath;
+    }
+
+    if (
+      typeof mapping.fromSourcemap === "string" &&
+      mapping.fromSourcemap.trim().length > 0
+    ) {
+      return path.resolve(process.cwd(), mapping.fromSourcemap);
+    }
+
+    return null;
+  }
+
+  private getSourcemapIndexForPath(
+    sourcemapPath: string,
+  ): ReturnType<typeof loadSourcemapPropertyIndex> {
+    const existing = this.sourcemapIndexByPath.get(sourcemapPath);
+    if (existing) {
+      return existing;
+    }
+
+    const loaded = loadSourcemapPropertyIndex(sourcemapPath);
+    this.sourcemapIndexByPath.set(sourcemapPath, loaded);
+    return loaded;
   }
 
   private inferSourcePrefixFromPath(

--- a/src/push.ts
+++ b/src/push.ts
@@ -29,8 +29,8 @@ interface PushOptions {
   usePlaceConfig?: boolean;
   rojoMode?: boolean;
   rojoProjectFile?: string;
-  applySourcemap?: boolean;
-  fromSourcemap?: boolean;
+  applySourcemapProperties?: boolean;
+  useSourcemapAsSource?: boolean;
   sourcemapPath?: string;
 }
 
@@ -183,7 +183,10 @@ export class PushCommand {
         continue;
       }
 
-      if (!useFromSourcemap && this.options.applySourcemap !== false) {
+      if (
+        !useFromSourcemap &&
+        this.options.applySourcemapProperties !== false
+      ) {
         const sourcemapIndex = this.getSourcemapIndexForPath(
           this.sourcemapPath,
         );
@@ -508,7 +511,7 @@ export class PushCommand {
   private resolveMappingSourcemapPath(mapping: {
     fromSourcemap?: string;
   }): string | null {
-    if (this.options.fromSourcemap) {
+    if (this.options.useSourcemapAsSource) {
       return this.sourcemapPath;
     }
 

--- a/src/sourcemap/propertyLoader.ts
+++ b/src/sourcemap/propertyLoader.ts
@@ -126,7 +126,7 @@ export function buildInstancesFromSourcemap(
 ): InstanceData[] | null {
   const resolved = path.resolve(sourcemapPath);
   if (!fs.existsSync(resolved)) {
-    log.warn(`Sourcemap not found at ${resolved}`);
+    log.error(`Sourcemap not found at ${resolved}`);
     return null;
   }
 

--- a/src/util/cliArgs.ts
+++ b/src/util/cliArgs.ts
@@ -1,0 +1,182 @@
+import { config } from "../config.js";
+import { parseArgs } from "node:util";
+
+export interface ParsedCliArgs {
+  command: string | null;
+
+  //   Global options
+  help: boolean;
+  version: boolean;
+  debug: boolean;
+  noWarn: boolean;
+  syncDir?: string;
+  port?: number;
+
+  //   Build/Push options
+  rojo: boolean;
+  rojoProject?: string;
+  fromSourcemap?: string;
+  //   fromSourcemapValue: string | null;
+  source?: string;
+  destination?: string;
+  noPlaceConfig: boolean;
+  destructive: boolean;
+
+  //   Pack options
+  output?: string;
+  scriptsOnly: boolean;
+
+  //   Config options
+  configPath: boolean;
+}
+
+export function parseCliArgs(argv: string[]): ParsedCliArgs {
+  const args = ensureOptionalStringFlagValues(argv, ["--from-sourcemap"]);
+
+  const { values, positionals } = parseArgs({
+    args,
+    strict: false,
+    allowPositionals: true,
+    options: {
+      // Global options
+      help: { type: "boolean", short: "h" },
+      version: { type: "boolean" },
+      debug: { type: "boolean" },
+      "no-warn": { type: "boolean" },
+      "sync-dir": { type: "string" },
+      port: { type: "string" },
+
+      // Build/Push options
+      rojo: { type: "boolean" },
+      "rojo-project": { type: "string" },
+      "from-sourcemap": { type: "string" },
+      source: { type: "string", short: "s" },
+      destination: { type: "string", short: "d" },
+      "no-place-config": { type: "boolean" },
+      destructive: { type: "boolean" },
+
+      // Pack options
+      output: { type: "string", short: "o" },
+      "scripts-only": { type: "boolean" },
+
+      // Config options
+      path: { type: "boolean" },
+    },
+  });
+
+  const command = positionals[0] ?? null;
+  //   const fromSourcemapRawValue = getStringOption(values, "from-sourcemap");
+
+  return {
+    command,
+    help: getBooleanOption(values, "help"),
+    version: getBooleanOption(values, "version"),
+    debug: getBooleanOption(values, "debug"),
+    noWarn: getBooleanOption(values, "no-warn"),
+    configPath: getBooleanOption(values, "path"),
+    syncDir: getStringOption(values, "sync-dir"),
+    port: getNumberOptionInRange(values, "port", 1, 65535),
+    rojo: getBooleanOption(values, "rojo"),
+    rojoProject: getStringOption(values, "rojo-project"),
+    fromSourcemap: getStringOptionWithImplicitDefault(
+      values,
+      "from-sourcemap",
+      config.sourcemapPath,
+    ),
+    // fromSourcemap: fromSourcemapRawValue !== undefined,
+    // fromSourcemapValue:
+    //   fromSourcemapRawValue === "" || fromSourcemapRawValue === undefined
+    //     ? null
+    //     : fromSourcemapRawValue,
+    source: getStringOption(values, "source"),
+    destination: getStringOption(values, "destination"),
+    noPlaceConfig: getBooleanOption(values, "no-place-config"),
+    destructive: getBooleanOption(values, "destructive"),
+    output: getStringOption(values, "output"),
+    scriptsOnly: getBooleanOption(values, "scripts-only"),
+  };
+}
+
+function getBooleanOption(
+  values: Record<string, string | boolean | undefined>,
+  flagName: string,
+): boolean {
+  return values[flagName] === true;
+}
+
+function getStringOption(
+  values: Record<string, string | boolean | undefined>,
+  flagName: string,
+  //   hasOptionalValue = false, // For flags that can be provided as --flag or --flag=value
+): string | undefined {
+  const flagValue = values[flagName];
+
+  return typeof flagValue === "string" ? flagValue : undefined;
+}
+
+function getStringOptionWithImplicitDefault(
+  values: Record<string, string | boolean | undefined>,
+  flagName: string,
+  defaultValue: string,
+): string | undefined {
+  const flagValue = values[flagName];
+
+  if (flagValue === undefined) {
+    return undefined;
+  }
+
+  if (flagValue === "") {
+    return defaultValue;
+  }
+
+  return typeof flagValue === "string" ? flagValue : undefined;
+}
+
+function getNumberOptionInRange(
+  values: Record<string, string | boolean | undefined>,
+  flagName: string,
+  min: number,
+  max: number,
+): undefined | number {
+  const value = getStringOption(values, flagName);
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const numberValue = Number(value);
+  if (isNaN(numberValue) || numberValue < min || numberValue > max) {
+    throw new Error(
+      `Invalid --${flagName} value "${value}": expected a number between ${min} and ${max}.`,
+    );
+  }
+
+  return numberValue;
+}
+
+function ensureOptionalStringFlagValues(
+  argv: string[],
+  flags: string[],
+): string[] {
+  const normalized: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const matchedFlag = flags.find((flag) => arg === flag);
+
+    if (!matchedFlag) {
+      normalized.push(arg);
+      continue;
+    }
+
+    const nextArg = argv[i + 1];
+    if (!nextArg || nextArg.startsWith("-")) {
+      normalized.push(`${matchedFlag}=`);
+      continue;
+    }
+
+    normalized.push(arg);
+  }
+
+  return normalized;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
     "lib": ["ES2022"],
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "rootDir": "./src",
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
## Daemon
- Add `--destructive`  flag for `azul build`
  -  Allows you to get clean builds from filesystem instead of manually clearing your place or using an empty one.
- Implement graceful shutdown when shutting down by CTRL+C
- Remove sourcemap question from interactive `build` menu if place config is used.
- Small fixes & QOL patches

## Plugin
- New field in per-place Daemon configuration: `fromSourcemap` 
```
fromSourcemap = "./sourcemap.json"
```
- Don't override previous DockWidget enabled state.
  - (the Plugin widget won't ignore if you closed it last session) 
- More explicit error in WebSocket message processing.
- Fix: Building to "protected" containers (i.e. `StarterPlayer`).
- Fix: Azul should no longer try to write to non-script instances in certain edge cases.