### PR TITLE
feat: add folder-backed script export option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,9 @@ export interface AzulConfig {
   /** Suffix ModuleScript names with ".module"? */
   suffixModuleScripts: boolean;
 
+  /** Export scripts with children as folder-backed init files? */
+  folderBackedScriptsWithChildren: boolean;
+
   /** Check for Daemon updates? (Uses NPM API) */
   checkForUpdates: boolean;
 }
@@ -49,6 +52,7 @@ export const defaultConfig: Readonly<AzulConfig> = {
   fileWatchDebounce: 100,
   deleteOrphansOnConnect: true,
   suffixModuleScripts: false,
+  folderBackedScriptsWithChildren: false,
   checkForUpdates: true,
 };
 
@@ -174,6 +178,11 @@ function sanitizeConfig(input: Record<string, unknown>): Partial<AzulConfig> {
 
   if (typeof input.suffixModuleScripts === "boolean") {
     sanitized.suffixModuleScripts = input.suffixModuleScripts;
+  }
+
+  if (typeof input.folderBackedScriptsWithChildren === "boolean") {
+    sanitized.folderBackedScriptsWithChildren =
+      input.folderBackedScriptsWithChildren;
   }
 
   if (typeof input.checkForUpdates === "boolean") {

--- a/src/fs/fileWriter.ts
+++ b/src/fs/fileWriter.ts
@@ -58,7 +58,11 @@ export class FileWriter {
     const dirsToCreate = new Set<string>();
     const batchPathToGuid = new Map<string, string>();
 
-    for (const node of nodes) {
+    const sortedNodes = [...nodes].sort(
+      (a, b) => a.path.length - b.path.length,
+    );
+
+    for (const node of sortedNodes) {
       if (!this.isScriptNode(node) || node.source === undefined) continue;
       const filePath = this.getFilePathWithCollisionMap(node, batchPathToGuid);
       const dirPath = path.dirname(filePath);
@@ -188,12 +192,12 @@ export class FileWriter {
     node: TreeNode,
     batchCollisionMap?: Map<string, string>,
   ): string {
-    // Build the path from the node's hierarchy. For scripts, we only use the parent path
-    // as directories, then add the script file name. This prevents creating an extra
-    // folder named after the script itself.
+    // Build the path from the node's hierarchy. Most scripts use the parent path
+    // as directories; folder-backed scripts use their own path plus an init file.
     const parts: string[] = [];
 
-    const dirSegments = this.isScriptNode(node)
+    const isFolderBackedScript = this.isFolderBackedScript(node);
+    const dirSegments = this.isScriptNode(node) && !isFolderBackedScript
       ? node.path.slice(0, Math.max(0, node.path.length - 1))
       : node.path;
 
@@ -203,7 +207,9 @@ export class FileWriter {
 
     // If this is a script, add the script name as a file
     if (this.isScriptNode(node)) {
-      const scriptName = this.getScriptFileName(node);
+      const scriptName = isFolderBackedScript
+        ? this.getFolderBackedInitFileName(node)
+        : this.getScriptFileName(node);
       parts.push(scriptName);
     }
 
@@ -253,6 +259,36 @@ export class FileWriter {
     }
 
     return `${name}${ext}`;
+  }
+
+  /**
+   * Get the init filename for scripts exported as folders containing descendants.
+   */
+  private getFolderBackedInitFileName(node: TreeNode): string {
+    const ext = config.scriptExtension;
+
+    if (node.className === "Script") {
+      return `init.server${ext}`;
+    }
+
+    if (node.className === "LocalScript") {
+      return `init.client${ext}`;
+    }
+
+    // Match regular ModuleScript naming: only add .module when that suffix is enabled.
+    if (node.className === "ModuleScript" && config.suffixModuleScripts) {
+      return `init.module${ext}`;
+    }
+
+    return `init${ext}`;
+  }
+
+  private isFolderBackedScript(node: TreeNode): boolean {
+    return (
+      config.folderBackedScriptsWithChildren &&
+      this.isScriptNode(node) &&
+      node.children.size > 0
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,7 @@ export class SyncDaemon {
    * Handle instance update (rename, move, etc.)
    */
   private handleInstanceUpdated(data: any): void {
+    const previousParent = this.tree.getNode(data.guid)?.parent;
     const update = this.tree.updateInstance(data);
     const node = update?.node;
 
@@ -200,6 +201,18 @@ export class SyncDaemon {
     }
 
     const scriptsToUpdate: Map<string, TreeNode> = new Map();
+    const layoutParentsToUpdate: Map<string, TreeNode> = new Map();
+
+    const addLayoutParent = (parent: TreeNode | undefined): void => {
+      if (
+        config.folderBackedScriptsWithChildren &&
+        parent &&
+        this.isScriptClass(parent.className)
+      ) {
+        layoutParentsToUpdate.set(parent.guid, parent);
+        scriptsToUpdate.set(parent.guid, parent);
+      }
+    };
 
     if (this.isScriptClass(node.className)) {
       scriptsToUpdate.set(node.guid, node);
@@ -211,7 +224,16 @@ export class SyncDaemon {
       }
     }
 
-    for (const scriptNode of scriptsToUpdate.values()) {
+    if (update.isNew || update.parentChanged) {
+      addLayoutParent(previousParent);
+      addLayoutParent(node.parent);
+    }
+
+    const sortedScriptsToUpdate = [...scriptsToUpdate.values()].sort(
+      (a, b) => a.path.length - b.path.length,
+    );
+
+    for (const scriptNode of sortedScriptsToUpdate) {
       const filePath = this.fileWriter.getFilePath(scriptNode);
       this.fileWatcher.suppressNextChange(filePath, scriptNode.source);
       this.fileWriter.writeScript(scriptNode);
@@ -235,6 +257,17 @@ export class SyncDaemon {
       );
     }
 
+    for (const layoutParent of layoutParentsToUpdate.values()) {
+      this.sourcemapGenerator.upsertSubtree(
+        layoutParent,
+        this.tree.getAllNodes(),
+        this.fileWriter.getAllMappings(),
+        config.sourcemapPath,
+        undefined,
+        false,
+      );
+    }
+
     this.fileWriter.cleanupEmptyDirectories();
   }
 
@@ -253,6 +286,13 @@ export class SyncDaemon {
       this.fileWriter.cleanupEmptyDirectories();
       return;
     }
+
+    const layoutParentToUpdate =
+      config.folderBackedScriptsWithChildren &&
+      node.parent &&
+      this.isScriptClass(node.parent.className)
+        ? node.parent
+        : undefined;
 
     // Capture all script descendants (and the node itself if script) before we delete the tree nodes
     const scriptsToDelete: { guid: string; filePath: string | null }[] = [];
@@ -302,6 +342,23 @@ export class SyncDaemon {
         log.debug("Regenerating sourcemap due to prune miss");
         this.regenerateSourcemap();
       }
+    }
+
+    if (layoutParentToUpdate) {
+      const filePath = this.fileWriter.getFilePath(layoutParentToUpdate);
+      this.fileWatcher.suppressNextChange(
+        filePath,
+        layoutParentToUpdate.source,
+      );
+      this.fileWriter.writeScript(layoutParentToUpdate);
+      this.sourcemapGenerator.upsertSubtree(
+        layoutParentToUpdate,
+        this.tree.getAllNodes(),
+        this.fileWriter.getAllMappings(),
+        config.sourcemapPath,
+        undefined,
+        false,
+      );
     }
 
     this.fileWriter.cleanupEmptyDirectories();


### PR DESCRIPTION
I'm trying out Azul after typically using Rojo. One issue I found is that Azul doesn't handle the structure of scripts with children under them the same way Rojo does. Rather than the rojo method:
```
ExampleScript/
├─ ExampleChild.luau
├─ init.luau
```
Azul will apply to the fs:
```
ExampleScript/
├─ ExampleChild.luau
ExampleScript.luau
```
which in my case is quite bad ergonomics when the containing folder of ExampleScript contains lots of scripts, each with their own child. The Rojo method of wrapping all the files into a single folder is quite natural and closer to standard unix philosophy.

I thought I'd add this feature myself and have tried it out (and it works nicely). Let me know if you think this would be a helpful addition to Azul.

I guarded it behind a config flag for backwards compatibility (folder backing disabled by default).

I also have another PR to update docs if wanted.