### PR TITLE
feat(daemon+sync): Add support for *.model.json instances

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -4,7 +4,7 @@ import { IPCServer } from "./ipc/server.js";
 import { config } from "./config.js";
 import { log } from "./util/log.js";
 import { SnapshotBuilder } from "./snapshot.js";
-import { RojoSnapshotBuilder } from "./snapshot/rojo.js";
+import { RojoSnapshotBuilder } from "./snapshot/rojo/index.js";
 import type { InstanceData } from "./ipc/messages.js";
 import {
   applySourcemapProperties,

--- a/src/push.ts
+++ b/src/push.ts
@@ -5,7 +5,7 @@ import { IPCServer } from "./ipc/server.js";
 import { config } from "./config.js";
 import { log } from "./util/log.js";
 import { SnapshotBuilder } from "./snapshot.js";
-import { RojoSnapshotBuilder } from "./snapshot/rojo.js";
+import { RojoSnapshotBuilder } from "./snapshot/rojo/index.js";
 import { generateGUID } from "./util/id.js";
 import { classifyScriptFileName, isInstanceJsonName, isScriptFileName } from "./util/scriptFile.js";
 import {

--- a/src/push.ts
+++ b/src/push.ts
@@ -7,7 +7,7 @@ import { log } from "./util/log.js";
 import { SnapshotBuilder } from "./snapshot.js";
 import { RojoSnapshotBuilder } from "./snapshot/rojo.js";
 import { generateGUID } from "./util/id.js";
-import { classifyScriptFileName, isScriptFileName } from "./util/scriptFile.js";
+import { classifyScriptFileName, isInstanceJsonName, isScriptFileName } from "./util/scriptFile.js";
 import {
   applySourcemapProperties,
   buildInstancesFromSourcemap,
@@ -852,7 +852,38 @@ export class PushCommand {
         (e) => e.isFile() && initCandidates.includes(e.name),
       );
 
-      if (initEntry) {
+      const initModelEntry = entries.find(
+        (e) => e.isFile() && e.name === "init.model.json",
+      );
+
+      if (initModelEntry) {
+        const full = path.join(dir, "init.model.json");
+        const destPath = [...destSegments, ...relSegments];
+        const key = destPath.join("/");
+        if (!emittedPaths.has(key)) {
+          this.ensureFolder(destPath.slice(0, -1), results, emittedFolders);
+          emittedPaths.add(key);
+          emittedFolders.add(key); // prevent folder emission at this path
+
+          const builder = new RojoSnapshotBuilder({ cwd: process.cwd() });
+          const modelInstances = await builder.parseModelFile(full, destPath);
+          if (modelInstances.length > 0) {
+            const rootInstance = modelInstances[0];
+            if (initEntry) {
+              const scriptClass = classifyScriptFileName(initEntry.name, {
+                stripDisambiguationSuffix: true,
+              }).className;
+              const source = await fsp.readFile(
+                path.join(dir, initEntry.name),
+                "utf-8",
+              );
+              rootInstance.className = scriptClass;
+              rootInstance.source = source;
+            }
+            results.push(...modelInstances);
+          }
+        }
+      } else if (initEntry) {
         const full = path.join(dir, initEntry.name);
         const { className } = classifyScriptFileName(initEntry.name, {
           stripDisambiguationSuffix: true,
@@ -884,7 +915,58 @@ export class PushCommand {
           continue; // already emitted as the container
         }
 
+        if (initModelEntry && entry.name === "init.model.json") {
+          continue;
+        }
+
+        if (isInstanceJsonName(entry.name)) {
+          const baseName = entry.name.slice(0, -".model.json".length);
+          const destPath = [...destSegments, ...relSegments, baseName];
+          const key = destPath.join("/");
+          if (emittedPaths.has(key)) continue;
+
+          this.ensureFolder(destPath.slice(0, -1), results, emittedFolders);
+          emittedPaths.add(key);
+
+          const builder = new RojoSnapshotBuilder({ cwd: process.cwd() });
+          const modelInstances = await builder.parseModelFile(full, destPath);
+          if (modelInstances.length > 0) {
+            const rootInstance = modelInstances[0];
+            const companionScript = entries.find(
+              (e) =>
+                e.isFile() &&
+                isScriptFileName(e.name) &&
+                classifyScriptFileName(e.name).scriptName === baseName,
+            );
+            if (companionScript) {
+              const scriptClass = classifyScriptFileName(companionScript.name, {
+                stripDisambiguationSuffix: true,
+              }).className;
+              const source = await fsp.readFile(
+                path.join(dir, companionScript.name),
+                "utf-8",
+              );
+              rootInstance.className = scriptClass;
+              rootInstance.source = source;
+            }
+            results.push(...modelInstances);
+          }
+          continue;
+        }
+
         if (!isScriptFileName(entry.name)) continue;
+
+        // Skip scripts that are companion scripts of a companion model file
+        const baseName = classifyScriptFileName(entry.name, {
+          stripDisambiguationSuffix: true,
+        }).scriptName;
+        const companionModelName = `${baseName}.model.json`;
+        const hasCompanionModel = entries.some(
+          (e) => e.isFile() && e.name === companionModelName,
+        );
+        if (hasCompanionModel) {
+          continue;
+        }
 
         const { className, scriptName } = classifyScriptFileName(entry.name, {
           stripDisambiguationSuffix: true,

--- a/src/snapshot/rojo.ts
+++ b/src/snapshot/rojo.ts
@@ -39,11 +39,12 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
       return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
     }
   }
+  /*
   if (normalizedType === "color3uint8") {
     if (Array.isArray(value) && value.length === 3) {
       return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
     }
-  }
+  } */
   if (normalizedType === "cframe") {
     if (Array.isArray(value)) {
       return { __type: "CFrame", components: value };

--- a/src/snapshot/rojo.ts
+++ b/src/snapshot/rojo.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { log } from "../util/log.js";
 import {
   classifyScriptFileName,
+  isInstanceJsonName,
   isScriptFileName,
   ScriptClassName,
 } from "../util/scriptFile.js";
@@ -19,6 +20,134 @@ export interface RojoSnapshotOptions {
   projectFile?: string;
   cwd?: string;
   destPrefix?: string[];
+}
+
+function convertExplicitRojoProperty(typeStr: string, value: any): any {
+  const normalizedType = typeStr.toLowerCase();
+  if (normalizedType === "vector3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Vector3", x: value[0], y: value[1], z: value[2] };
+    }
+  }
+  if (normalizedType === "vector2") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "Vector2", x: value[0], y: value[1] };
+    }
+  }
+  if (normalizedType === "color3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "color3uint8") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "cframe") {
+    if (Array.isArray(value)) {
+      return { __type: "CFrame", components: value };
+    }
+  }
+  if (normalizedType === "udim") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "UDim", scale: value[0], offset: value[1] };
+    }
+  }
+  if (normalizedType === "udim2") {
+    if (Array.isArray(value) && value.length === 4) {
+      return { __type: "UDim2", xScale: value[0], xOffset: value[1], yScale: value[2], yOffset: value[3] };
+    }
+  }
+  if (normalizedType === "brickcolor") {
+    return { __type: "BrickColor", number: typeof value === "number" ? value : 0 };
+  }
+  if (normalizedType === "numberrange") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "NumberRange", min: value[0], max: value[1] };
+    }
+  }
+  if (normalizedType === "rect") {
+    if (Array.isArray(value)) {
+      if (value.length === 4) {
+        return { __type: "Rect", minX: value[0], minY: value[1], maxX: value[2], maxY: value[3] };
+      }
+      if (value.length === 2 && Array.isArray(value[0]) && Array.isArray(value[1])) {
+        return { __type: "Rect", minX: value[0][0], minY: value[0][1], maxX: value[1][0], maxY: value[1][1] };
+      }
+    }
+  }
+  if (normalizedType === "enum") {
+    if (typeof value === "object" && value !== null) {
+      const enumType = value.enumType || value.EnumType || value.Type || value.type;
+      const enumValue = value.value || value.Value || value.name || value.Name;
+      if (enumType && enumValue !== undefined) {
+        return {
+          __type: "Enum",
+          enumType: String(enumType).replace(/^Enum\./, ""),
+          value: enumValue
+        };
+      }
+    }
+    return value;
+  }
+  return value;
+}
+
+export function convertImplicitRojoProperty(propName: string, val: any): any {
+  if (val === null || val === undefined) {
+    return null;
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "Type" in val && "Value" in val) {
+    return convertExplicitRojoProperty(val.Type, val.Value);
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "type" in val && "value" in val) {
+    return convertExplicitRojoProperty(val.type, val.value);
+  }
+
+  if (Array.isArray(val)) {
+    const allNumbers = val.every(v => typeof v === 'number');
+    if (allNumbers) {
+      const lowerName = propName.toLowerCase();
+      if (val.length === 12) {
+        return { __type: "CFrame", components: val };
+      }
+      if (val.length === 3) {
+        if (lowerName.includes("color")) {
+          if (val.some(v => v > 1.0)) {
+            return { __type: "Color3uint8", r: val[0], g: val[1], b: val[2] };
+          }
+          return { __type: "Color3", r: val[0], g: val[1], b: val[2] };
+        }
+        return { __type: "Vector3", x: val[0], y: val[1], z: val[2] };
+      }
+      if (val.length === 2) {
+        if (lowerName.includes("range")) {
+          return { __type: "NumberRange", min: val[0], max: val[1] };
+        }
+        if (lowerName.includes("udim") || lowerName.includes("size") || lowerName.includes("position")) {
+          return { __type: "UDim", scale: val[0], offset: val[1] };
+        }
+        return { __type: "Vector2", x: val[0], y: val[1] };
+      }
+      if (val.length === 4) {
+        if (lowerName.includes("rect")) {
+          return { __type: "Rect", minX: val[0], minY: val[1], maxX: val[2], maxY: val[3] };
+        }
+        return { __type: "UDim2", xScale: val[0], xOffset: val[1], yScale: val[2], yOffset: val[3] };
+      }
+    }
+  }
+
+  if (typeof val === "object" && val !== null) {
+    const copy: Record<string, any> = {};
+    for (const [k, v] of Object.entries(val)) {
+      copy[k] = convertImplicitRojoProperty(k, v);
+    }
+    return copy;
+  }
+
+  return val;
 }
 
 /**
@@ -230,6 +359,155 @@ export class RojoSnapshotBuilder {
     }
   }
 
+  public async parseModelFile(
+    filePath: string,
+    destPath: string[],
+  ): Promise<InstanceData[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch (error) {
+      throw new Error(`Failed to read .model.json at ${filePath}: ${error}`);
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(`Failed to parse .model.json at ${filePath}: ${error}`);
+    }
+
+    const results: InstanceData[] = [];
+    const name = destPath[destPath.length - 1] || "Model";
+    await this.parseModelNode(parsed, name, destPath, path.dirname(filePath), results);
+    return results;
+  }
+
+  private async parseModelNode(
+    node: any,
+    name: string,
+    currentPath: string[],
+    baseDir: string,
+    results: InstanceData[],
+  ): Promise<void> {
+    if (typeof node !== "object" || node === null) return;
+
+    // Check for $path
+    const pathHint = node.$path || node.path;
+    if (typeof pathHint === "string") {
+      const absPath = path.resolve(baseDir, pathHint);
+      const exists = await this.exists(absPath);
+      if (!exists) {
+        throw new Error(`$path target ${absPath} does not exist.`);
+      }
+
+      const kind = await this.pathKind(absPath);
+      if (kind === "file") {
+        const fileName = path.basename(absPath);
+        if (isInstanceJsonName(fileName)) {
+          const modelInstances = await this.parseModelFile(absPath, currentPath);
+          results.push(...modelInstances);
+          return;
+        } else if (this.isJsonModuleFile(fileName)) {
+          const source = await this.readJsonModuleSource(absPath);
+          this.moduleContainers.add(currentPath.join("/"));
+          results.push({
+            guid: this.makeGuid(),
+            className: "ModuleScript",
+            name,
+            path: [...currentPath],
+            source,
+          });
+          return;
+        } else if (isScriptFileName(fileName)) {
+          const { className } = classifyScriptFileName(fileName);
+          const source = await fs.readFile(absPath, "utf-8");
+          this.moduleContainers.add(currentPath.join("/"));
+          results.push({
+            guid: this.makeGuid(),
+            className,
+            name,
+            path: [...currentPath],
+            source,
+          });
+          return;
+        } else {
+          throw new Error(`Unsupported $path file type: ${absPath}`);
+        }
+      } else if (kind === "dir") {
+        await this.walkDirectory(absPath, currentPath, results, new Set());
+        return;
+      }
+    }
+
+    const className = node.ClassName || node.className || node.$className || "Folder";
+    
+    // Resolve properties
+    const rawProperties = node.Properties || node.properties || node.$properties;
+    const properties: Record<string, any> = {};
+    if (rawProperties && typeof rawProperties === "object") {
+      for (const [k, v] of Object.entries(rawProperties)) {
+        properties[k] = convertImplicitRojoProperty(k, v);
+      }
+    }
+
+    // Resolve attributes
+    const rawAttributes = node.Attributes || node.attributes || node.$attributes;
+    const attributes: Record<string, any> = {};
+    if (rawAttributes && typeof rawAttributes === "object") {
+      for (const [k, v] of Object.entries(rawAttributes)) {
+        attributes[k] = v;
+      }
+    }
+
+    // Resolve tags
+    const rawTags = node.Tags || node.tags || node.$tags;
+    let tags: string[] | undefined = undefined;
+    if (Array.isArray(rawTags)) {
+      tags = rawTags.map(t => String(t));
+    }
+
+    const instance: InstanceData = {
+      guid: this.makeGuid(),
+      className,
+      name,
+      path: [...currentPath],
+    };
+
+    if (Object.keys(properties).length > 0) {
+      instance.properties = properties;
+    }
+    if (Object.keys(attributes).length > 0) {
+      instance.attributes = attributes;
+    }
+    if (tags && tags.length > 0) {
+      instance.tags = tags;
+    }
+
+    this.moduleContainers.add(currentPath.join("/"));
+    results.push(instance);
+
+    // Recursively parse children
+    const rawChildren = node.Children || node.children || node.$children;
+    if (Array.isArray(rawChildren)) {
+      for (let i = 0; i < rawChildren.length; i++) {
+        const childNode = rawChildren[i];
+        if (typeof childNode === "object" && childNode !== null) {
+          const childName = childNode.Name || childNode.name || childNode.$name || `Instance${i}`;
+          const childPath = [...currentPath, childName];
+          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+        }
+      }
+    } else if (rawChildren && typeof rawChildren === "object") {
+      for (const [childName, childNode] of Object.entries(rawChildren)) {
+        if (typeof childNode === "object" && childNode !== null) {
+          const childPath = [...currentPath, childName];
+          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+        }
+      }
+    }
+  }
+
   private async emitNode(
     name: string,
     node: Record<string, any>,
@@ -250,11 +528,69 @@ export class RojoSnapshotBuilder {
       source: string;
       className?: ScriptClassName;
     } | null = null;
+    let initModelFile: string | null = null;
+
     if (absPath && pathKind === "dir") {
+      const modelPath = path.join(absPath, "init.model.json");
+      if (await this.exists(modelPath)) {
+        initModelFile = modelPath;
+      }
       initScript = await this.findInit(absPath);
     } else if (absPath && pathKind === "file") {
       const fileName = path.basename(absPath);
-      if (this.isJsonModuleFile(fileName)) {
+      if (isInstanceJsonName(fileName)) {
+        this.ensureFolder(pathSegments.slice(0, -1), results);
+        const modelInstances = await this.parseModelFile(absPath, pathSegments);
+        if (modelInstances.length > 0) {
+          const rootInstance = modelInstances[0];
+          
+          if (node.$className) {
+            rootInstance.className = node.$className;
+          }
+          
+          if (node.$properties) {
+            const mergedProps = { ...(rootInstance.properties || {}) };
+            for (const [k, v] of Object.entries(node.$properties)) {
+              mergedProps[k] = convertImplicitRojoProperty(k, v);
+            }
+            rootInstance.properties = mergedProps;
+          }
+
+          if (node.$attributes) {
+            const mergedAttrs = { ...(rootInstance.attributes || {}) };
+            for (const [k, v] of Object.entries(node.$attributes)) {
+              mergedAttrs[k] = v;
+            }
+            rootInstance.attributes = mergedAttrs;
+          }
+
+          if (node.$tags) {
+            const existingTags = new Set(rootInstance.tags || []);
+            if (Array.isArray(node.$tags)) {
+              for (const tag of node.$tags) {
+                existingTags.add(String(tag));
+              }
+            }
+            rootInstance.tags = [...existingTags];
+          }
+
+          results.push(...modelInstances);
+        }
+
+        // Recurse into children defined in JSON
+        for (const [childName, childValue] of Object.entries(node)) {
+          if (childName.startsWith("$")) continue;
+          if (typeof childValue !== "object" || childValue === null) continue;
+          await this.emitNode(
+            childName,
+            childValue,
+            [...pathSegments, childName],
+            projectDir,
+            results,
+          );
+        }
+        return;
+      } else if (this.isJsonModuleFile(fileName)) {
         const source = await this.readJsonModuleSource(absPath);
         initScript = { fileName, source, className: "ModuleScript" };
       } else {
@@ -266,8 +602,55 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    // If there's an init script, the folder becomes a ModuleScript at the same path.
-    if (initScript) {
+    if (initModelFile) {
+      this.ensureFolder(pathSegments.slice(0, -1), results);
+      this.moduleContainers.add(pathSegments.join("/"));
+      
+      const modelInstances = await this.parseModelFile(initModelFile, pathSegments);
+      if (modelInstances.length > 0) {
+        const rootInstance = modelInstances[0];
+        
+        if (node.$className) {
+          rootInstance.className = node.$className;
+        }
+        
+        if (node.$properties) {
+          const mergedProps = { ...(rootInstance.properties || {}) };
+          for (const [k, v] of Object.entries(node.$properties)) {
+            mergedProps[k] = convertImplicitRojoProperty(k, v);
+          }
+          rootInstance.properties = mergedProps;
+        }
+
+        if (node.$attributes) {
+          const mergedAttrs = { ...(rootInstance.attributes || {}) };
+          for (const [k, v] of Object.entries(node.$attributes)) {
+            mergedAttrs[k] = v;
+          }
+          rootInstance.attributes = mergedAttrs;
+        }
+
+        if (node.$tags) {
+          const existingTags = new Set(rootInstance.tags || []);
+          if (Array.isArray(node.$tags)) {
+            for (const tag of node.$tags) {
+              existingTags.add(String(tag));
+            }
+          }
+          rootInstance.tags = [...existingTags];
+        }
+
+        if (initScript) {
+          const scriptClass =
+            initScript.className ??
+            classifyScriptFileName(initScript.fileName).className;
+          rootInstance.className = scriptClass;
+          rootInstance.source = initScript.source;
+        }
+
+        results.push(...modelInstances);
+      }
+    } else if (initScript) {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       this.moduleContainers.add(pathSegments.join("/"));
       const scriptClass =
@@ -339,8 +722,40 @@ export class RojoSnapshotBuilder {
       (e) => e.isFile() && initCandidates.includes(e.name),
     );
 
-    if (initEntry) {
-      const key = destPath.join("/");
+    const initModelEntry = entries.find(
+      (e) => e.isFile() && e.name === "init.model.json"
+    );
+
+    const handledEntries = new Set<string>();
+    const key = destPath.join("/");
+
+    if (initModelEntry) {
+      handledEntries.add("init.model.json");
+      if (!this.moduleContainers.has(key)) {
+        this.moduleContainers.add(key);
+        this.ensureFolder(destPath.slice(0, -1), results);
+        
+        const modelInstances = await this.parseModelFile(
+          path.join(dirPath, "init.model.json"),
+          destPath,
+        );
+        if (modelInstances.length > 0) {
+          const rootInstance = modelInstances[0];
+          if (initEntry) {
+            handledEntries.add(initEntry.name);
+            const scriptClass = classifyScriptFileName(initEntry.name).className;
+            const source = await fs.readFile(
+              path.join(dirPath, initEntry.name),
+              "utf-8",
+            );
+            rootInstance.className = scriptClass;
+            rootInstance.source = source;
+          }
+          results.push(...modelInstances);
+        }
+      }
+    } else if (initEntry) {
+      handledEntries.add(initEntry.name);
       if (!this.moduleContainers.has(key)) {
         this.moduleContainers.add(key);
         this.ensureFolder(destPath.slice(0, -1), results);
@@ -378,11 +793,44 @@ export class RojoSnapshotBuilder {
     }
 
     for (const entry of entries) {
+      if (handledEntries.has(entry.name)) continue;
       const fullPath = path.join(dirPath, entry.name);
       if (this.isIgnored(fullPath)) continue;
 
       // Skip entries explicitly defined in the project tree
       if (definedChildren.has(entry.name)) {
+        continue;
+      }
+
+      if (entry.isFile() && entry.name.endsWith(".model.json") && entry.name !== "init.model.json") {
+        handledEntries.add(entry.name);
+        const baseName = entry.name.slice(0, -".model.json".length);
+        if (definedChildren.has(baseName)) {
+          continue;
+        }
+
+        this.ensureFolder(destPath, results);
+        const modelInstances = await this.parseModelFile(fullPath, [...destPath, baseName]);
+        if (modelInstances.length > 0) {
+          const rootInstance = modelInstances[0];
+          const companionScript = entries.find(
+            (e) =>
+              e.isFile() &&
+              isScriptFileName(e.name) &&
+              classifyScriptFileName(e.name).scriptName === baseName,
+          );
+          if (companionScript) {
+            handledEntries.add(companionScript.name);
+            const scriptClass = classifyScriptFileName(companionScript.name).className;
+            const source = await fs.readFile(
+              path.join(dirPath, companionScript.name),
+              "utf-8",
+            );
+            rootInstance.className = scriptClass;
+            rootInstance.source = source;
+          }
+          results.push(...modelInstances);
+        }
         continue;
       }
 

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -23,6 +23,9 @@ export interface RojoSnapshotOptions {
   destPrefix?: string[];
 }
 
+/**
+ * Builds InstanceData[] from a Rojo-style default.project.json (compat layer).
+ */
 export class RojoSnapshotBuilder {
   private projectFile: string;
   private cwd: string;
@@ -54,10 +57,16 @@ export class RojoSnapshotBuilder {
 
     log.debug(`destPrefix: ${this.destPrefix.join("/")}`);
 
+    // If the root of the project tree doesn't have a $className of "Datamodel", the Rojo project is not a Place and
+    // we cannot guess the root of the emitted tree.
     if (
       (!tree.$className || tree.$className !== "Datamodel") &&
       (!this.destPrefix || this.destPrefix.length === 0)
     ) {
+      /**
+       * Rojo error:
+       * Cannot sync a model as a place. Ensure Rojo is serving a project file that has a DataModel at the root of its tree and try again.
+       */
       log.error(
         `Cannot build Rojo compatibility snapshot: project file does not have a Datamodel root.`,
       );
@@ -97,6 +106,7 @@ export class RojoSnapshotBuilder {
         );
         const source = await fs.readFile(absRoot, "utf-8");
 
+        // If the root is a file, it becomes the single instance emitted at the destPrefix (or root if no prefix).
         const destPath =
           this.destPrefix.length === 0
             ? [scriptName]
@@ -123,10 +133,12 @@ export class RojoSnapshotBuilder {
       }
     }
 
+    // Walk any children defined in the root of the project tree (if $path is not a file)
     if (hasChildren) {
       await this.walkTree(tree, [], projectDir, results);
     }
 
+    // Stable ordering: shallow-first, then lexical for determinism
     results.sort((a, b) => {
       if (a.path.length !== b.path.length) {
         return a.path.length - b.path.length;
@@ -240,7 +252,13 @@ export class RojoSnapshotBuilder {
 
     const results: InstanceData[] = [];
     const name = destPath[destPath.length - 1] || "Model";
-    await this.parseModelNode(parsed, name, destPath, path.dirname(filePath), results);
+    await this.parseModelNode(
+      parsed,
+      name,
+      destPath,
+      path.dirname(filePath),
+      results,
+    );
     return results;
   }
 
@@ -265,7 +283,10 @@ export class RojoSnapshotBuilder {
       if (kind === "file") {
         const fileName = path.basename(absPath);
         if (isInstanceJsonName(fileName)) {
-          const modelInstances = await this.parseModelFile(absPath, currentPath);
+          const modelInstances = await this.parseModelFile(
+            absPath,
+            currentPath,
+          );
           results.push(...modelInstances);
           return;
         } else if (this.isJsonModuleFile(fileName)) {
@@ -300,9 +321,11 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    const className = node.ClassName || node.className || node.$className || "Folder";
+    const className =
+      node.ClassName || node.className || node.$className || "Folder";
 
-    const rawProperties = node.Properties || node.properties || node.$properties;
+    const rawProperties =
+      node.Properties || node.properties || node.$properties;
     const properties: Record<string, any> = {};
     if (rawProperties && typeof rawProperties === "object") {
       for (const [k, v] of Object.entries(rawProperties)) {
@@ -310,7 +333,8 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    const rawAttributes = node.Attributes || node.attributes || node.$attributes;
+    const rawAttributes =
+      node.Attributes || node.attributes || node.$attributes;
     const attributes: Record<string, any> = {};
     if (rawAttributes && typeof rawAttributes === "object") {
       for (const [k, v] of Object.entries(rawAttributes)) {
@@ -321,7 +345,7 @@ export class RojoSnapshotBuilder {
     const rawTags = node.Tags || node.tags || node.$tags;
     let tags: string[] | undefined = undefined;
     if (Array.isArray(rawTags)) {
-      tags = rawTags.map(t => String(t));
+      tags = rawTags.map((t) => String(t));
     }
 
     const instance: InstanceData = {
@@ -349,16 +373,32 @@ export class RojoSnapshotBuilder {
       for (let i = 0; i < rawChildren.length; i++) {
         const childNode = rawChildren[i];
         if (typeof childNode === "object" && childNode !== null) {
-          const childName = childNode.Name || childNode.name || childNode.$name || `Instance${i}`;
+          const childName =
+            childNode.Name ||
+            childNode.name ||
+            childNode.$name ||
+            `Instance${i}`;
           const childPath = [...currentPath, childName];
-          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+          await this.parseModelNode(
+            childNode,
+            childName,
+            childPath,
+            baseDir,
+            results,
+          );
         }
       }
     } else if (rawChildren && typeof rawChildren === "object") {
       for (const [childName, childNode] of Object.entries(rawChildren)) {
         if (typeof childNode === "object" && childNode !== null) {
           const childPath = [...currentPath, childName];
-          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+          await this.parseModelNode(
+            childNode,
+            childName,
+            childPath,
+            baseDir,
+            results,
+          );
         }
       }
     }
@@ -399,11 +439,11 @@ export class RojoSnapshotBuilder {
         const modelInstances = await this.parseModelFile(absPath, pathSegments);
         if (modelInstances.length > 0) {
           const rootInstance = modelInstances[0];
-          
+
           if (node.$className) {
             rootInstance.className = node.$className;
           }
-          
+
           if (node.$properties) {
             const mergedProps = { ...(rootInstance.properties || {}) };
             for (const [k, v] of Object.entries(node.$properties)) {
@@ -457,18 +497,22 @@ export class RojoSnapshotBuilder {
       }
     }
 
+    // If there's an init script or an init model file, the folder becomes that instance.
     if (initModelFile) {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       this.moduleContainers.add(pathSegments.join("/"));
-      
-      const modelInstances = await this.parseModelFile(initModelFile, pathSegments);
+
+      const modelInstances = await this.parseModelFile(
+        initModelFile,
+        pathSegments,
+      );
       if (modelInstances.length > 0) {
         const rootInstance = modelInstances[0];
-        
+
         if (node.$className) {
           rootInstance.className = node.$className;
         }
-        
+
         if (node.$properties) {
           const mergedProps = { ...(rootInstance.properties || {}) };
           for (const [k, v] of Object.entries(node.$properties)) {
@@ -505,7 +549,10 @@ export class RojoSnapshotBuilder {
 
         results.push(...modelInstances);
       }
-    } else if (initScript) {
+    }
+
+    // If there's an init script, the folder becomes a ModuleScript at the same path.
+    else if (initScript) {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       this.moduleContainers.add(pathSegments.join("/"));
       const scriptClass =
@@ -518,7 +565,9 @@ export class RojoSnapshotBuilder {
         path: [...pathSegments],
         source: initScript.source,
       });
-    } else {
+    }
+    // If no special file (model or script) was found, emit a standard instance.
+    else {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       results.push({
         guid: this.makeGuid(),
@@ -528,6 +577,7 @@ export class RojoSnapshotBuilder {
       });
     }
 
+    // Recurse into children defined in JSON
     for (const [childName, childValue] of Object.entries(node)) {
       if (childName.startsWith("$")) continue;
       if (typeof childValue !== "object" || childValue === null) continue;
@@ -540,6 +590,7 @@ export class RojoSnapshotBuilder {
       );
     }
 
+    // Walk filesystem for $path mappings
     if (absPath && pathKind === "dir") {
       await this.walkDirectory(absPath, pathSegments, results, definedChildren);
     }
@@ -553,6 +604,7 @@ export class RojoSnapshotBuilder {
       return node.$className;
     }
     if (pathSegments.length === 1) {
+      // Service root
       return pathSegments[0];
     }
     return "Folder";
@@ -569,12 +621,13 @@ export class RojoSnapshotBuilder {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
     const initCandidates = this.getInitCandidates();
 
+    // If this directory has an init, the directory becomes that script; children attach under it
     const initEntry = entries.find(
       (e) => e.isFile() && initCandidates.includes(e.name),
     );
 
     const initModelEntry = entries.find(
-      (e) => e.isFile() && e.name === "init.model.json"
+      (e) => e.isFile() && e.name === "init.model.json",
     );
 
     const handledEntries = new Set<string>();
@@ -585,7 +638,7 @@ export class RojoSnapshotBuilder {
       if (!this.moduleContainers.has(key)) {
         this.moduleContainers.add(key);
         this.ensureFolder(destPath.slice(0, -1), results);
-        
+
         const modelInstances = await this.parseModelFile(
           path.join(dirPath, "init.model.json"),
           destPath,
@@ -594,7 +647,9 @@ export class RojoSnapshotBuilder {
           const rootInstance = modelInstances[0];
           if (initEntry) {
             handledEntries.add(initEntry.name);
-            const scriptClass = classifyScriptFileName(initEntry.name).className;
+            const scriptClass = classifyScriptFileName(
+              initEntry.name,
+            ).className;
             const source = await fs.readFile(
               path.join(dirPath, initEntry.name),
               "utf-8",
@@ -627,6 +682,7 @@ export class RojoSnapshotBuilder {
       this.ensureFolder(destPath, results);
     }
 
+    // Sub-project overrides
     const subProjectPath = path.join(dirPath, "default.project.json");
     if (await this.exists(subProjectPath)) {
       const previousProjectFile = this.projectFile;
@@ -647,11 +703,16 @@ export class RojoSnapshotBuilder {
       const fullPath = path.join(dirPath, entry.name);
       if (this.isIgnored(fullPath)) continue;
 
+      // Skip entries explicitly defined in the project tree
       if (definedChildren.has(entry.name)) {
         continue;
       }
 
-      if (entry.isFile() && entry.name.endsWith(".model.json") && entry.name !== "init.model.json") {
+      if (
+        entry.isFile() &&
+        entry.name.endsWith(".model.json") &&
+        entry.name !== "init.model.json"
+      ) {
         handledEntries.add(entry.name);
         const baseName = entry.name.slice(0, -".model.json".length);
         if (definedChildren.has(baseName)) {
@@ -659,7 +720,10 @@ export class RojoSnapshotBuilder {
         }
 
         this.ensureFolder(destPath, results);
-        const modelInstances = await this.parseModelFile(fullPath, [...destPath, baseName]);
+        const modelInstances = await this.parseModelFile(fullPath, [
+          ...destPath,
+          baseName,
+        ]);
         if (modelInstances.length > 0) {
           const rootInstance = modelInstances[0];
           const companionScript = entries.find(
@@ -670,7 +734,9 @@ export class RojoSnapshotBuilder {
           );
           if (companionScript) {
             handledEntries.add(companionScript.name);
-            const scriptClass = classifyScriptFileName(companionScript.name).className;
+            const scriptClass = classifyScriptFileName(
+              companionScript.name,
+            ).className;
             const source = await fs.readFile(
               path.join(dirPath, companionScript.name),
               "utf-8",
@@ -693,6 +759,7 @@ export class RojoSnapshotBuilder {
         continue;
       }
 
+      // Skip init files here (handled earlier)
       if (initCandidates.includes(entry.name)) {
         continue;
       }
@@ -736,6 +803,9 @@ export class RojoSnapshotBuilder {
     }
   }
 
+  /**
+   * Ensure a Folder chain exists for the given path.
+   */
   private ensureFolder(pathSegments: string[], results: InstanceData[]): void {
     if (pathSegments.length === 0) return;
     const key = pathSegments.join("/");
@@ -751,6 +821,11 @@ export class RojoSnapshotBuilder {
     });
   }
 
+  /**
+   * Finds an init script (init.lua, init.server.luau, etc.) in a directory.
+   * @param dirPath
+   * @returns The file name and source of the init script, or null if not found.
+   */
   private async findInit(
     dirPath: string,
   ): Promise<{ fileName: string; source: string } | null> {
@@ -767,6 +842,9 @@ export class RojoSnapshotBuilder {
     return null;
   }
 
+  /**
+   * Returns a list of potential init script filenames.
+   */
   private getInitCandidates(): string[] {
     const bases = ["init", "init.server", "init.client", "init.module"];
 

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -1,14 +1,15 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { log } from "../util/log.js";
+import { log } from "../../util/log.js";
 import {
   classifyScriptFileName,
   isInstanceJsonName,
   isScriptFileName,
   ScriptClassName,
-} from "../util/scriptFile.js";
-import type { InstanceData } from "../ipc/messages.js";
+} from "../../util/scriptFile.js";
+import type { InstanceData } from "../../ipc/messages.js";
+import { convertImplicitRojoProperty } from "./convert.js";
 
 interface RojoProject {
   name: string;
@@ -22,138 +23,6 @@ export interface RojoSnapshotOptions {
   destPrefix?: string[];
 }
 
-function convertExplicitRojoProperty(typeStr: string, value: any): any {
-  const normalizedType = typeStr.toLowerCase();
-  if (normalizedType === "vector3") {
-    if (Array.isArray(value) && value.length === 3) {
-      return { __type: "Vector3", x: value[0], y: value[1], z: value[2] };
-    }
-  }
-  if (normalizedType === "vector2") {
-    if (Array.isArray(value) && value.length === 2) {
-      return { __type: "Vector2", x: value[0], y: value[1] };
-    }
-  }
-  if (normalizedType === "color3") {
-    if (Array.isArray(value) && value.length === 3) {
-      return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
-    }
-  }
-  /*
-  if (normalizedType === "color3uint8") {
-    if (Array.isArray(value) && value.length === 3) {
-      return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
-    }
-  } */
-  if (normalizedType === "cframe") {
-    if (Array.isArray(value)) {
-      return { __type: "CFrame", components: value };
-    }
-  }
-  if (normalizedType === "udim") {
-    if (Array.isArray(value) && value.length === 2) {
-      return { __type: "UDim", scale: value[0], offset: value[1] };
-    }
-  }
-  if (normalizedType === "udim2") {
-    if (Array.isArray(value) && value.length === 4) {
-      return { __type: "UDim2", xScale: value[0], xOffset: value[1], yScale: value[2], yOffset: value[3] };
-    }
-  }
-  if (normalizedType === "brickcolor") {
-    return { __type: "BrickColor", number: typeof value === "number" ? value : 0 };
-  }
-  if (normalizedType === "numberrange") {
-    if (Array.isArray(value) && value.length === 2) {
-      return { __type: "NumberRange", min: value[0], max: value[1] };
-    }
-  }
-  if (normalizedType === "rect") {
-    if (Array.isArray(value)) {
-      if (value.length === 4) {
-        return { __type: "Rect", minX: value[0], minY: value[1], maxX: value[2], maxY: value[3] };
-      }
-      if (value.length === 2 && Array.isArray(value[0]) && Array.isArray(value[1])) {
-        return { __type: "Rect", minX: value[0][0], minY: value[0][1], maxX: value[1][0], maxY: value[1][1] };
-      }
-    }
-  }
-  if (normalizedType === "enum") {
-    if (typeof value === "object" && value !== null) {
-      const enumType = value.enumType || value.EnumType || value.Type || value.type;
-      const enumValue = value.value || value.Value || value.name || value.Name;
-      if (enumType && enumValue !== undefined) {
-        return {
-          __type: "Enum",
-          enumType: String(enumType).replace(/^Enum\./, ""),
-          value: enumValue
-        };
-      }
-    }
-    return value;
-  }
-  return value;
-}
-
-export function convertImplicitRojoProperty(propName: string, val: any): any {
-  if (val === null || val === undefined) {
-    return null;
-  }
-  if (typeof val === "object" && !Array.isArray(val) && "Type" in val && "Value" in val) {
-    return convertExplicitRojoProperty(val.Type, val.Value);
-  }
-  if (typeof val === "object" && !Array.isArray(val) && "type" in val && "value" in val) {
-    return convertExplicitRojoProperty(val.type, val.value);
-  }
-
-  if (Array.isArray(val)) {
-    const allNumbers = val.every(v => typeof v === 'number');
-    if (allNumbers) {
-      const lowerName = propName.toLowerCase();
-      if (val.length === 12) {
-        return { __type: "CFrame", components: val };
-      }
-      if (val.length === 3) {
-        if (lowerName.includes("color")) {
-          if (val.some(v => v > 1.0)) {
-            return { __type: "Color3uint8", r: val[0], g: val[1], b: val[2] };
-          }
-          return { __type: "Color3", r: val[0], g: val[1], b: val[2] };
-        }
-        return { __type: "Vector3", x: val[0], y: val[1], z: val[2] };
-      }
-      if (val.length === 2) {
-        if (lowerName.includes("range")) {
-          return { __type: "NumberRange", min: val[0], max: val[1] };
-        }
-        if (lowerName.includes("udim") || lowerName.includes("size") || lowerName.includes("position")) {
-          return { __type: "UDim", scale: val[0], offset: val[1] };
-        }
-        return { __type: "Vector2", x: val[0], y: val[1] };
-      }
-      if (val.length === 4) {
-        if (lowerName.includes("rect")) {
-          return { __type: "Rect", minX: val[0], minY: val[1], maxX: val[2], maxY: val[3] };
-        }
-        return { __type: "UDim2", xScale: val[0], xOffset: val[1], yScale: val[2], yOffset: val[3] };
-      }
-    }
-  }
-
-  if (typeof val === "object" && val !== null) {
-    const copy: Record<string, any> = {};
-    for (const [k, v] of Object.entries(val)) {
-      copy[k] = convertImplicitRojoProperty(k, v);
-    }
-    return copy;
-  }
-
-  return val;
-}
-
-/**
- * Builds InstanceData[] from a Rojo-style default.project.json (compat layer).
- */
 export class RojoSnapshotBuilder {
   private projectFile: string;
   private cwd: string;
@@ -185,16 +54,10 @@ export class RojoSnapshotBuilder {
 
     log.debug(`destPrefix: ${this.destPrefix.join("/")}`);
 
-    // If the root of the project tree doesn't have a $className of "Datamodel", the Rojo project is not a Place and
-    // we cannot guess the root of the emitted tree.
     if (
       (!tree.$className || tree.$className !== "Datamodel") &&
       (!this.destPrefix || this.destPrefix.length === 0)
     ) {
-      /**
-       * Rojo error:
-       * Cannot sync a model as a place. Ensure Rojo is serving a project file that has a DataModel at the root of its tree and try again.
-       */
       log.error(
         `Cannot build Rojo compatibility snapshot: project file does not have a Datamodel root.`,
       );
@@ -234,7 +97,6 @@ export class RojoSnapshotBuilder {
         );
         const source = await fs.readFile(absRoot, "utf-8");
 
-        // If the root is a file, it becomes the single instance emitted at the destPrefix (or root if no prefix).
         const destPath =
           this.destPrefix.length === 0
             ? [scriptName]
@@ -261,12 +123,10 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    // Walk any children defined in the root of the project tree (if $path is not a file)
     if (hasChildren) {
       await this.walkTree(tree, [], projectDir, results);
     }
 
-    // Stable ordering: shallow-first, then lexical for determinism
     results.sort((a, b) => {
       if (a.path.length !== b.path.length) {
         return a.path.length - b.path.length;
@@ -393,7 +253,6 @@ export class RojoSnapshotBuilder {
   ): Promise<void> {
     if (typeof node !== "object" || node === null) return;
 
-    // Check for $path
     const pathHint = node.$path || node.path;
     if (typeof pathHint === "string") {
       const absPath = path.resolve(baseDir, pathHint);
@@ -442,8 +301,7 @@ export class RojoSnapshotBuilder {
     }
 
     const className = node.ClassName || node.className || node.$className || "Folder";
-    
-    // Resolve properties
+
     const rawProperties = node.Properties || node.properties || node.$properties;
     const properties: Record<string, any> = {};
     if (rawProperties && typeof rawProperties === "object") {
@@ -452,16 +310,14 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    // Resolve attributes
     const rawAttributes = node.Attributes || node.attributes || node.$attributes;
     const attributes: Record<string, any> = {};
     if (rawAttributes && typeof rawAttributes === "object") {
       for (const [k, v] of Object.entries(rawAttributes)) {
-        attributes[k] = v;
+        attributes[k] = convertImplicitRojoProperty(k, v);
       }
     }
 
-    // Resolve tags
     const rawTags = node.Tags || node.tags || node.$tags;
     let tags: string[] | undefined = undefined;
     if (Array.isArray(rawTags)) {
@@ -488,7 +344,6 @@ export class RojoSnapshotBuilder {
     this.moduleContainers.add(currentPath.join("/"));
     results.push(instance);
 
-    // Recursively parse children
     const rawChildren = node.Children || node.children || node.$children;
     if (Array.isArray(rawChildren)) {
       for (let i = 0; i < rawChildren.length; i++) {
@@ -578,7 +433,6 @@ export class RojoSnapshotBuilder {
           results.push(...modelInstances);
         }
 
-        // Recurse into children defined in JSON
         for (const [childName, childValue] of Object.entries(node)) {
           if (childName.startsWith("$")) continue;
           if (typeof childValue !== "object" || childValue === null) continue;
@@ -674,7 +528,6 @@ export class RojoSnapshotBuilder {
       });
     }
 
-    // Recurse into children defined in JSON
     for (const [childName, childValue] of Object.entries(node)) {
       if (childName.startsWith("$")) continue;
       if (typeof childValue !== "object" || childValue === null) continue;
@@ -687,7 +540,6 @@ export class RojoSnapshotBuilder {
       );
     }
 
-    // Walk filesystem for $path mappings
     if (absPath && pathKind === "dir") {
       await this.walkDirectory(absPath, pathSegments, results, definedChildren);
     }
@@ -701,7 +553,6 @@ export class RojoSnapshotBuilder {
       return node.$className;
     }
     if (pathSegments.length === 1) {
-      // Service root
       return pathSegments[0];
     }
     return "Folder";
@@ -718,7 +569,6 @@ export class RojoSnapshotBuilder {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
     const initCandidates = this.getInitCandidates();
 
-    // If this directory has an init, the directory becomes that script; children attach under it
     const initEntry = entries.find(
       (e) => e.isFile() && initCandidates.includes(e.name),
     );
@@ -777,7 +627,6 @@ export class RojoSnapshotBuilder {
       this.ensureFolder(destPath, results);
     }
 
-    // Sub-project override
     const subProjectPath = path.join(dirPath, "default.project.json");
     if (await this.exists(subProjectPath)) {
       const previousProjectFile = this.projectFile;
@@ -798,7 +647,6 @@ export class RojoSnapshotBuilder {
       const fullPath = path.join(dirPath, entry.name);
       if (this.isIgnored(fullPath)) continue;
 
-      // Skip entries explicitly defined in the project tree
       if (definedChildren.has(entry.name)) {
         continue;
       }
@@ -846,7 +694,6 @@ export class RojoSnapshotBuilder {
         continue;
       }
 
-      // Skip init files here (handled earlier)
       if (initCandidates.includes(entry.name)) {
         continue;
       }
@@ -890,15 +737,11 @@ export class RojoSnapshotBuilder {
     }
   }
 
-  /**
-   * Ensure a Folder chain exists for the given path.
-   */
   private ensureFolder(pathSegments: string[], results: InstanceData[]): void {
     if (pathSegments.length === 0) return;
     const key = pathSegments.join("/");
     if (this.moduleContainers.has(key)) return;
     if (this.emittedFolders.has(key)) return;
-    // ensure parents first
     this.ensureFolder(pathSegments.slice(0, -1), results);
     this.emittedFolders.add(key);
     results.push({

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -684,7 +684,6 @@ export class RojoSnapshotBuilder {
       }
 
       if (entry.isDirectory()) {
-        this.ensureFolder([...destPath, entry.name], results);
         await this.walkDirectory(
           fullPath,
           [...destPath, entry.name],

--- a/src/snapshot/rojo/convert.ts
+++ b/src/snapshot/rojo/convert.ts
@@ -115,9 +115,9 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
     if (typeof value === "object" && value !== null) {
       return {
         __type: "Axes",
-        X: value.X ?? value.x ?? true,
-        Y: value.Y ?? value.y ?? true,
-        Z: value.Z ?? value.z ?? true,
+        x: value.X ?? value.x ?? true,
+        y: value.Y ?? value.y ?? true,
+        z: value.Z ?? value.z ?? true,
       };
     }
   }
@@ -125,19 +125,23 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
     if (typeof value === "object" && value !== null) {
       return {
         __type: "Faces",
-        Top: value.Top ?? value.top ?? false,
-        Bottom: value.Bottom ?? value.bottom ?? false,
-        Left: value.Left ?? value.left ?? false,
-        Right: value.Right ?? value.right ?? false,
-        Front: value.Front ?? value.front ?? false,
-        Back: value.Back ?? value.back ?? false,
+        top: value.Top ?? value.top ?? false,
+        bottom: value.Bottom ?? value.bottom ?? false,
+        left: value.Left ?? value.left ?? false,
+        right: value.Right ?? value.right ?? false,
+        front: value.Front ?? value.front ?? false,
+        back: value.Back ?? value.back ?? false,
       };
     }
   }
   if (normalizedType === "ray") {
     if (typeof value === "object" && value !== null) {
-      const origin = Array.isArray(value.origin ?? value.Origin) ? { x: value.origin[0], y: value.origin[1], z: value.origin[2] } : { x: 0, y: 0, z: 0 };
-      const direction = Array.isArray(value.direction ?? value.Direction) ? { x: value.direction[0], y: value.direction[1], z: value.direction[2] } : { x: 0, y: 0, z: 1 };
+      const origin = Array.isArray(value.origin ?? value.Origin)
+        ? { __type: "Vector3", x: value.origin[0], y: value.origin[1], z: value.origin[2] }
+        : { __type: "Vector3", x: 0, y: 0, z: 0 };
+      const direction = Array.isArray(value.direction ?? value.Direction)
+        ? { __type: "Vector3", x: value.direction[0], y: value.direction[1], z: value.direction[2] }
+        : { __type: "Vector3", x: 0, y: 0, z: 1 };
       return { __type: "Ray", origin, direction };
     }
   }

--- a/src/snapshot/rojo/convert.ts
+++ b/src/snapshot/rojo/convert.ts
@@ -1,0 +1,321 @@
+function convertExplicitRojoProperty(typeStr: string, value: any): any {
+  const normalizedType = typeStr.toLowerCase();
+  if (normalizedType === "vector3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Vector3", x: value[0], y: value[1], z: value[2] };
+    }
+    if (typeof value === "object" && value !== null) {
+      return { __type: "Vector3", x: value.x ?? value.X ?? 0, y: value.y ?? value.Y ?? 0, z: value.z ?? value.Z ?? 0 };
+    }
+  }
+  if (normalizedType === "vector2") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "Vector2", x: value[0], y: value[1] };
+    }
+    if (typeof value === "object" && value !== null) {
+      return { __type: "Vector2", x: value.x ?? value.X ?? 0, y: value.y ?? value.Y ?? 0 };
+    }
+  }
+  if (normalizedType === "vector2int16") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "Vector2int16", x: value[0], y: value[1] };
+    }
+  }
+  if (normalizedType === "vector3int16") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Vector3int16", x: value[0], y: value[1], z: value[2] };
+    }
+  }
+  if (normalizedType === "color3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "color3uint8") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "cframe") {
+    if (Array.isArray(value)) {
+      return { __type: "CFrame", components: value };
+    }
+  }
+  if (normalizedType === "udim") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "UDim", scale: value[0], offset: value[1] };
+    }
+  }
+  if (normalizedType === "udim2") {
+    if (Array.isArray(value) && value.length === 4) {
+      return { __type: "UDim2", xScale: value[0], xOffset: value[1], yScale: value[2], yOffset: value[3] };
+    }
+  }
+  if (normalizedType === "brickcolor") {
+    return { __type: "BrickColor", number: typeof value === "number" ? value : 0 };
+  }
+  if (normalizedType === "numberrange") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "NumberRange", min: value[0], max: value[1] };
+    }
+  }
+  if (normalizedType === "numbersequence") {
+    if (Array.isArray(value)) {
+      const keypoints = value.map((kp: any) => {
+        if (Array.isArray(kp)) {
+          return { time: kp[0], value: kp[1], envelope: kp[2] ?? 0 };
+        }
+        if (typeof kp === "object" && kp !== null) {
+          return { time: kp.time ?? kp.Time ?? 0, value: kp.value ?? kp.Value ?? 0, envelope: kp.envelope ?? kp.Envelope ?? 0 };
+        }
+        return { time: 0, value: Number(kp), envelope: 0 };
+      });
+      return { __type: "NumberSequence", keypoints };
+    }
+  }
+  if (normalizedType === "colorsequence") {
+    if (Array.isArray(value)) {
+      const keypoints = value.map((kp: any) => {
+        if (Array.isArray(kp)) {
+          return { time: kp[0], value: [kp[1], kp[2], kp[3]], envelope: kp[4] ?? 0 };
+        }
+        if (typeof kp === "object" && kp !== null) {
+          const c = kp.value ?? kp.Value;
+          const color = Array.isArray(c) ? c : [1, 1, 1];
+          return { time: kp.time ?? kp.Time ?? 0, value: color, envelope: kp.envelope ?? kp.Envelope ?? 0 };
+        }
+        return { time: 0, value: [1, 1, 1], envelope: 0 };
+      });
+      return { __type: "ColorSequence", keypoints };
+    }
+  }
+  if (normalizedType === "rect") {
+    if (Array.isArray(value)) {
+      if (value.length === 4) {
+        return { __type: "Rect", minX: value[0], minY: value[1], maxX: value[2], maxY: value[3] };
+      }
+      if (value.length === 2 && Array.isArray(value[0]) && Array.isArray(value[1])) {
+        return { __type: "Rect", minX: value[0][0], minY: value[0][1], maxX: value[1][0], maxY: value[1][1] };
+      }
+    }
+  }
+  if (normalizedType === "physicalproperties") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "PhysicalProperties",
+        density: value.Density ?? value.density ?? 0.7,
+        friction: value.Friction ?? value.friction ?? 0.5,
+        elasticity: value.Elasticity ?? value.elasticity ?? 0.3,
+        frictionWeight: value.FrictionWeight ?? value.frictionWeight ?? 1.0,
+        elasticityWeight: value.ElasticityWeight ?? value.elasticityWeight ?? 1.0,
+      };
+    }
+  }
+  if (normalizedType === "axes") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "Axes",
+        X: value.X ?? value.x ?? true,
+        Y: value.Y ?? value.y ?? true,
+        Z: value.Z ?? value.z ?? true,
+      };
+    }
+  }
+  if (normalizedType === "faces") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "Faces",
+        Top: value.Top ?? value.top ?? false,
+        Bottom: value.Bottom ?? value.bottom ?? false,
+        Left: value.Left ?? value.left ?? false,
+        Right: value.Right ?? value.right ?? false,
+        Front: value.Front ?? value.front ?? false,
+        Back: value.Back ?? value.back ?? false,
+      };
+    }
+  }
+  if (normalizedType === "ray") {
+    if (typeof value === "object" && value !== null) {
+      const origin = Array.isArray(value.origin ?? value.Origin) ? { x: value.origin[0], y: value.origin[1], z: value.origin[2] } : { x: 0, y: 0, z: 0 };
+      const direction = Array.isArray(value.direction ?? value.Direction) ? { x: value.direction[0], y: value.direction[1], z: value.direction[2] } : { x: 0, y: 0, z: 1 };
+      return { __type: "Ray", origin, direction };
+    }
+  }
+  if (normalizedType === "region3") {
+    if (typeof value === "object" && value !== null) {
+      const min = value.min ?? value.Min;
+      const max = value.max ?? value.Max;
+      return {
+        __type: "Region3",
+        min: Array.isArray(min) ? { x: min[0], y: min[1], z: min[2] } : min ?? { x: 0, y: 0, z: 0 },
+        max: Array.isArray(max) ? { x: max[0], y: max[1], z: max[2] } : max ?? { x: 0, y: 0, z: 0 },
+      };
+    }
+  }
+  if (normalizedType === "region3int16") {
+    if (typeof value === "object" && value !== null) {
+      const min = value.min ?? value.Min;
+      const max = value.max ?? value.Max;
+      return {
+        __type: "Region3int16",
+        min: Array.isArray(min) ? { x: min[0], y: min[1], z: min[2] } : min ?? { x: 0, y: 0, z: 0 },
+        max: Array.isArray(max) ? { x: max[0], y: max[1], z: max[2] } : max ?? { x: 0, y: 0, z: 0 },
+      };
+    }
+  }
+  if (normalizedType === "font") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "Font",
+        family: value.Family ?? value.family ?? "",
+        weight: value.Weight ?? value.weight ?? "Regular",
+        style: value.Style ?? value.style ?? "Normal",
+      };
+    }
+  }
+  if (normalizedType === "tags") {
+    if (Array.isArray(value)) {
+      return { __type: "Tags", tags: value.map(String) };
+    }
+  }
+  if (normalizedType === "enum") {
+    if (typeof value === "object" && value !== null) {
+      const enumType = value.enumType || value.EnumType || value.Type || value.type;
+      const enumValue = value.value || value.Value || value.name || value.Name;
+      if (enumType && enumValue !== undefined) {
+        return {
+          __type: "Enum",
+          enumType: String(enumType).replace(/^Enum\./, ""),
+          value: enumValue
+        };
+      }
+    }
+    return value;
+  }
+  return value;
+}
+
+export function convertImplicitRojoProperty(propName: string, val: any): any {
+  if (val === null || val === undefined) {
+    return null;
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "Type" in val && "Value" in val) {
+    return convertExplicitRojoProperty(val.Type, val.Value);
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "type" in val && "value" in val) {
+    return convertExplicitRojoProperty(val.type, val.value);
+  }
+
+  if (typeof val === "string") {
+    return val;
+  }
+
+  if (typeof val === "boolean") {
+    return val;
+  }
+
+  if (typeof val === "number") {
+    return val;
+  }
+
+  if (Array.isArray(val)) {
+    const allStrings = val.every(v => typeof v === 'string');
+    if (allStrings && val.length > 0) {
+      return { __type: "Tags", tags: val.map(String) };
+    }
+
+    const allNumbers = val.every(v => typeof v === 'number');
+    if (allNumbers) {
+      const lowerName = propName.toLowerCase();
+      if (val.length === 12) {
+        return { __type: "CFrame", components: val };
+      }
+      if (val.length === 3) {
+        if (lowerName.includes("color")) {
+          if (val.some(v => v > 1.0)) {
+            return { __type: "Color3uint8", r: val[0], g: val[1], b: val[2] };
+          }
+          return { __type: "Color3", r: val[0], g: val[1], b: val[2] };
+        }
+        return { __type: "Vector3", x: val[0], y: val[1], z: val[2] };
+      }
+      if (val.length === 2) {
+        if (lowerName.includes("range")) {
+          return { __type: "NumberRange", min: val[0], max: val[1] };
+        }
+        if (lowerName.includes("udim") || lowerName.includes("size") || lowerName.includes("position")) {
+          return { __type: "UDim", scale: val[0], offset: val[1] };
+        }
+        return { __type: "Vector2", x: val[0], y: val[1] };
+      }
+      if (val.length === 4) {
+        if (lowerName.includes("rect")) {
+          return { __type: "Rect", minX: val[0], minY: val[1], maxX: val[2], maxY: val[3] };
+        }
+        return { __type: "UDim2", xScale: val[0], xOffset: val[1], yScale: val[2], yOffset: val[3] };
+      }
+    }
+
+    const allArraysOfTwo = val.every((v: any) => Array.isArray(v) && v.length >= 2 && v.every((n: any) => typeof n === 'number'));
+    if (allArraysOfTwo && val.length > 0) {
+      const sampleLen = val[0].length;
+      if (sampleLen <= 3) {
+        return {
+          __type: "NumberSequence",
+          keypoints: val.map((kp: any) => ({ time: kp[0], value: kp[1], envelope: kp[2] ?? 0 }))
+        };
+      }
+      if (sampleLen >= 4) {
+        return {
+          __type: "ColorSequence",
+          keypoints: val.map((kp: any) => ({ time: kp[0], value: [kp[1], kp[2], kp[3]], envelope: kp[4] ?? 0 }))
+        };
+      }
+    }
+
+    const allKeypointObjects = val.every((v: any) =>
+      typeof v === "object" && v !== null && !Array.isArray(v) && ("time" in v || "Time" in v) && ("value" in v || "Value" in v)
+    );
+    if (allKeypointObjects && val.length > 0) {
+      const first = val[0];
+      const colorVal = first.value ?? first.Value;
+      if (Array.isArray(colorVal) && colorVal.length === 3) {
+        return {
+          __type: "ColorSequence",
+          keypoints: val.map((kp: any) => ({
+            time: kp.time ?? kp.Time ?? 0,
+            value: Array.isArray(kp.value ?? kp.Value) ? [kp.value[0], kp.value[1], kp.value[2]] : [1, 1, 1],
+            envelope: kp.envelope ?? kp.Envelope ?? 0
+          }))
+        };
+      }
+      return {
+        __type: "NumberSequence",
+        keypoints: val.map((kp: any) => ({
+          time: kp.time ?? kp.Time ?? 0,
+          value: kp.value ?? kp.Value ?? 0,
+          envelope: kp.envelope ?? kp.Envelope ?? 0
+        }))
+      };
+    }
+  }
+
+  if (typeof val === "object" && val !== null) {
+    if ("family" in val || "Family" in val) {
+      return {
+        __type: "Font",
+        family: val.Family ?? val.family ?? "",
+        weight: val.Weight ?? val.weight ?? "Regular",
+        style: val.Style ?? val.style ?? "Normal",
+      };
+    }
+
+    const copy: Record<string, any> = {};
+    for (const [k, v] of Object.entries(val)) {
+      copy[k] = convertImplicitRojoProperty(k, v);
+    }
+    return copy;
+  }
+
+  return val;
+}

--- a/src/snapshot/rojo/index.ts
+++ b/src/snapshot/rojo/index.ts
@@ -1,0 +1,2 @@
+export { RojoSnapshotBuilder } from "./builder.js";
+export type { RojoSnapshotOptions } from "./builder.js";

--- a/src/util/scriptFile.ts
+++ b/src/util/scriptFile.ts
@@ -23,6 +23,11 @@ export function isScriptFileName(fileName: string): boolean {
   return fileName.endsWith(".lua") || fileName.endsWith(".luau");
 }
 
+export function isInstanceJsonName(fileName: string): boolean {
+  return fileName.endsWith(".model.json") 
+  // || fileName.endsWith(".meta.json"); // No support for this yet
+}
+
 export function normalizeLuaLikeFileName(fileName: string): string {
   return fileName.replace(/\.lua$/i, ".luau");
 }


### PR DESCRIPTION
- Introduced support for parsing and handling init.model.json files.
- Updated logic to ensure proper processing of instance JSON files.

<details>
<summary><b>Implementation Checklist & Type Support</b></summary>

### Supported Instances & Properties (Fully Handled)

The following types are parsed from `.model.json` properties, either using the explicit `{ "Type": "Type", "Value": ... }` syntax or inferred implicitly from array structures, and are mapped directly to Azul serialization formats:

*  **Vector3** — Explicitly handled or implicitly inferred from a 3-element numeric array `[x, y, z]` *(unless the property name contains `"color"`)*.
*  **Vector2** — Explicitly handled or implicitly inferred from a 2-element numeric array `[x, y]` *(unless the property name contains `"range"`, `"udim"`, `"size"`, or `"position"`)*.
*  **Color3 / ~~Color3uint8~~** — Explicitly handled or implicitly inferred from a 3-element numeric array `[r, g, b]` when the property name contains `"color"`. ~~If any value is $> 1.0$, it automatically promotes to `Color3uint8` (0-255)~~.
*  **CFrame** — Explicitly handled or implicitly inferred from a 12-element numeric array.
*  **UDim** — Explicitly handled or implicitly inferred from a 2-element numeric array when the property name contains `"udim"`, `"size"`, or `"position"`.
*  **UDim2** — Explicitly handled or implicitly inferred from a 4-element numeric array.
*  **Rect** — Explicitly handled or implicitly inferred from a 4-element numeric array when the property name contains `"rect"`.
*  **BrickColor** — Explicitly handled from a numeric color ID.
*  **NumberRange** — Explicitly handled or implicitly inferred from a 2-element numeric array when the property name contains `"range"`.
*  **Enum / EnumItem** — Explicitly handled using either a string (e.g., `"Enum.Material.Wood"` or `"Wood"`), a number (e.g., `512`), or an object containing `enumType`/`value`.
*  **Basic Types** — `boolean`, `string`, and `number` are passed through natively.

---

###  WIP / Partially Supported

* ⚠️ **Ref (Instance References)** — *Partially Supported*. Rojo supports instance references (e.g., linking `PrimaryPart` to a child instance). While the companion plugin contains some `InstanceRef` deserialization code, resolving local/relative path references is not yet fully supported in this sync layer.
*  **NumberSequence / ColorSequence / PhysicalProperties**
*  **Axes / Faces / Ray**  *Not Supported*
* ~~`*.meta.json` — *Not Supported*~~ Not planned.
</details>


### Demo Video

https://github.com/user-attachments/assets/45ad7309-e5da-4cb1-9077-1176e370f115

<img width="653" height="161" alt="image" src="https://github.com/user-attachments/assets/0e048ffa-5d1e-44e3-b436-aa8e3ea73dd9" />
