### PR TITLE
Daemon 1.6.0 & Plugin v44

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 **/StudioWidgets/** linguist-vendored
+**/Packages/** linguist-vendored

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Azul allows you to use professional-grade tools like Visual Studio Code in Roblo
 
 _Yes, the name is a pun on Rojo (Spanish for "red"). Azul means "blue"!_
 
-<a href="#quick-start"><b>Quick Start</b></a> — <a href="#why-azul"><b>Why Azul</b></a> — <a href="https://azul-docs.vercel.app"><b>Documentation</b></a>
+<a href="#quick-start"><b>Quick Start</b></a> — <a href="#why-azul"><b>Why Azul</b></a> — <a href="https://azul.ransomwave.games"><b>Documentation</b></a> — <a href="https://azul.ransomwave.games/discord"><b>Discord</b></a>
 
 ## Philosophy
 
@@ -21,9 +21,9 @@ While Azul mainly follows this philosophy, it doesn't cut you off from the files
 - - [x] 🔄 **Bi-directional sync**: Changes in Studio update files, and file edits update Studio
 - - [x] 🌳 **DataModel mirroring**: Instance hierarchy 1:1 mapped to folder structure
 - - [x] 🎯 **No manual config / required structure**: Works out of the box with new and existing Roblox Studio projects, regardless of structure
-- - [x] 🏗️ **[Build command](https://azul-docs.vercel.app/getting-started/projects/#build-from-an-existing-local-project)**: Sync your local files into Studio with `azul build`.
-- - [x] 📦 **[Push command](https://azul-docs.vercel.app/commands/#azul-push)**: Selectively push local files into Studio using `azul push`. Useful when importing external libraries or using package managers (i.e Wally)
-- - [x] 🏛️ **[Fully hermetic builds](https://azul-docs.vercel.app/commands/#azul-pack)**: Fully serialize Instance properties using `azul pack`, allowing for clean, reproductible builds when `build`ing or `push`ing.
+- - [x] 🏗️ **[Build command](https://azul.ransomwave.games/getting-started/projects/#build-from-an-existing-local-project)**: Sync your local files into Studio with `azul build`.
+- - [x] 📦 **[Push command](https://azul.ransomwave.games/commands/#azul-push)**: Selectively push local files into Studio using `azul push`. Useful when importing external libraries or using package managers (i.e Wally)
+- - [x] 🏛️ **[Fully hermetic builds](https://azul.ransomwave.games/commands/#azul-pack)**: Fully serialize Instance properties using `azul pack`, allowing for clean, reproductible builds when `build`ing or `push`ing.
 - - [x] 🔴 **Rojo compatibility mode**: Supports importing from Rojo projects with the `--rojo` flag.
 - - [x] 🗺️ **Automatic sourcemap generation**: Generates a Rojo-compatible `sourcemap.json` so tools like Luau-lsp work out of the box.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azul-sync",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azul-sync",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "npm run build && node --test dist/tests/daemon.test.js dist/tests/snapshot.test.js dist/tests/rojo.test.js dist/tests/property_loader.test.js dist/tests/pack.test.js",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azul-sync",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Azul is an easy but powerful Studio-first, two-way synchronization tool for Roblox development. Edit your Roblox projects using your favorite IDE, while keeping everything in sync with Roblox Studio in real-time.",
   "main": "dist/index.js",
   "type": "module",

--- a/plugin/stylua.toml
+++ b/plugin/stylua.toml
@@ -1,1 +1,2 @@
 call_parentheses = "Input"
+collapse_simple_statement = "Always"

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -347,13 +347,13 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 								}),
 							}),
 							section("Connection", {
-								infoText("Automatically attempt to connect to the daemon on startup."),
 								labeledToggle("Auto Connect", self.autoConnect, function(newValue)
 									Config.AUTO_CONNECT = newValue
 									if self.callbacks.onAutoConnectChanged then
 										self.callbacks.onAutoConnectChanged(newValue)
 									end
 								end),
+								infoText("Automatically attempt to connect to the daemon on startup."),
 								labeledInput("WebSocket URL", self.wsUrlRef, {
 									Text = "ws://localhost:8080",
 									Finished = function(text)

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -43,6 +43,7 @@ export type CallbackFunctions = {
 	onStopSync: () -> (),
 	onDebugModeChanged: (boolean) -> ()?,
 	onSilentModeChanged: (boolean) -> ()?,
+	onAutoConnectChanged: (boolean) -> ()?,
 	onConfigChanged: (string, any) -> (),
 	onSettingsScopeChanged: (string) -> (),
 	onSourcemapReload: () -> (),
@@ -68,6 +69,7 @@ type AzulUI = {
 	handshakeComplete: fusion.Value<boolean>,
 	debugMode: fusion.Value<boolean>,
 	silentMode: fusion.Value<boolean>,
+	autoConnect: fusion.Value<boolean>,
 	settingsScopeValue: fusion.Value<string>,
 	listTypeValue: fusion.Value<string>,
 
@@ -228,6 +230,7 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 	self.handshakeComplete = Value(false)
 	self.debugMode = Value(Config.DEBUG_MODE)
 	self.silentMode = Value(Config.SILENT_MODE)
+	self.autoConnect = Value(Config.AUTO_CONNECT)
 	self.settingsScopeValue = Value(settingsScope == Enums.scope.GLOBAL and "Global" or "Project")
 	self.listTypeValue = Value(Config.LIST_TYPE == Enums.listType.WHITELIST and "Whitelist" or "Blacklist")
 
@@ -344,6 +347,13 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 								}),
 							}),
 							section("Connection", {
+								infoText("Automatically attempt to connect to the daemon on startup."),
+								labeledToggle("Auto Connect", self.autoConnect, function(newValue)
+									Config.AUTO_CONNECT = newValue
+									if self.callbacks.onAutoConnectChanged then
+										self.callbacks.onAutoConnectChanged(newValue)
+									end
+								end),
 								labeledInput("WebSocket URL", self.wsUrlRef, {
 									Text = "ws://localhost:8080",
 									Finished = function(text)

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -40,7 +40,7 @@ UI.__index = UI
 
 export type CallbackFunctions = {
 	onStartSync: () -> (),
-	onStopSync: (boolean?) -> (),
+	onStopSync: () -> (),
 	onAutoConnectChanged: (boolean) -> ()?,
 	onDebugModeChanged: (boolean) -> ()?,
 	onSilentModeChanged: (boolean) -> ()?,

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -78,7 +78,7 @@ type AzulUI = {
 	batchIdleRef: fusion.Value<TextBox?>,
 	scriptDebounceRef: fusion.Value<TextBox?>,
 
-	maxConnectionsRef: fusion.Value<TextBox?>,
+	maxHandshakesRef: fusion.Value<TextBox?>,
 	maxReconnectionsRef: fusion.Value<TextBox?>,
 	reconnectionIntervalRef: fusion.Value<TextBox?>,
 	

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -40,7 +40,7 @@ UI.__index = UI
 
 export type CallbackFunctions = {
 	onStartSync: () -> (),
-	onStopSync: () -> (),
+	onStopSync: (boolean?) -> (),
 	onAutoConnectChanged: (boolean) -> ()?,
 	onDebugModeChanged: (boolean) -> ()?,
 	onSilentModeChanged: (boolean) -> ()?,
@@ -563,7 +563,7 @@ function UI:UpdateConfig()
 	local reconnectionIntervalInput = peek(self.reconnectionIntervalRef)
 	if reconnectionIntervalInput then reconnectionIntervalInput.Text = tostring(Config.RECONNECTION_INTERVAL) end
 
-	
+
 	local serviceListInput = peek(self.serviceListRef)
 	if serviceListInput then serviceListInput.Text = table.concat(Config.SERVICE_LIST, ", ") end
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -555,7 +555,7 @@ function UI:UpdateConfig()
 
 
 	local maxConnectionsInput = peek(self.maxHandshakesRef)
-	if maxConnectionsInput then maxConnectionsInput.Text = tostring(Config.MAX_HANDSHAKESS) end
+	if maxConnectionsInput then maxConnectionsInput.Text = tostring(Config.MAX_HANDSHAKES) end
 
 	local maxReconnectionsInput = peek(self.maxReconnectionsRef)
 	if maxReconnectionsInput then maxReconnectionsInput.Text = tostring(Config.MAX_RECONNECTIONS) end

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -41,9 +41,9 @@ UI.__index = UI
 export type CallbackFunctions = {
 	onStartSync: () -> (),
 	onStopSync: () -> (),
+	onAutoConnectChanged: (boolean) -> ()?,
 	onDebugModeChanged: (boolean) -> ()?,
 	onSilentModeChanged: (boolean) -> ()?,
-	onAutoConnectChanged: (boolean) -> ()?,
 	onConfigChanged: (string, any) -> (),
 	onSettingsScopeChanged: (string) -> (),
 	onSourcemapReload: () -> (),
@@ -67,9 +67,9 @@ type AzulUI = {
 	isOpen: fusion.Value<boolean>,
 	syncEnabled: fusion.Value<boolean>,
 	handshakeComplete: fusion.Value<boolean>,
+	autoConnect: fusion.Value<boolean>,
 	debugMode: fusion.Value<boolean>,
 	silentMode: fusion.Value<boolean>,
-	autoConnect: fusion.Value<boolean>,
 	settingsScopeValue: fusion.Value<string>,
 	listTypeValue: fusion.Value<string>,
 
@@ -77,6 +77,11 @@ type AzulUI = {
 	heartbeatRef: fusion.Value<TextBox?>,
 	batchIdleRef: fusion.Value<TextBox?>,
 	scriptDebounceRef: fusion.Value<TextBox?>,
+
+	maxConnectionsRef: fusion.Value<TextBox?>,
+	maxReconnectionsRef: fusion.Value<TextBox?>,
+	reconnectionIntervalRef: fusion.Value<TextBox?>,
+	
 	serviceListRef: fusion.Value<TextBox?>,
 	excludedParentsRef: fusion.Value<TextBox?>,
 
@@ -100,16 +105,22 @@ local function debugPrint(...)
 end
 
 --- Utility function to validate number input from TextBoxes. If the number is valid, it calls the provided callback with the number value.
-local function validateNumberInput(newValue: string, callback: (number) -> ())
+local function validateNumberInput(newValue: string, callback: (number) -> (), allowNegative: boolean?)
 	local numberValue = tonumber(newValue)
+
 	if not numberValue then
 		warn(`[Azul::{script}]: Invalid number input: {newValue}`)
 		return
 	end
-	if numberValue <= 0 then
+
+	if not allowNegative and numberValue <= 0 then
 		warn(`[Azul::{script}]: Number input must be greater than 0: {newValue}`)
 		return
+	elseif numberValue == 0 then
+		warn(`[Azul::{script}]: Number input cannot be 0`)
+		return
 	end
+
 	callback(numberValue)
 end
 
@@ -228,9 +239,9 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 	self.isOpen = Value(true)
 	self.syncEnabled = Value(false)
 	self.handshakeComplete = Value(false)
+	self.autoConnect = Value(Config.AUTO_CONNECT)
 	self.debugMode = Value(Config.DEBUG_MODE)
 	self.silentMode = Value(Config.SILENT_MODE)
-	self.autoConnect = Value(Config.AUTO_CONNECT)
 	self.settingsScopeValue = Value(settingsScope == Enums.scope.GLOBAL and "Global" or "Project")
 	self.listTypeValue = Value(Config.LIST_TYPE == Enums.listType.WHITELIST and "Whitelist" or "Blacklist")
 
@@ -238,6 +249,11 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 	self.heartbeatRef = Value(nil)
 	self.batchIdleRef = Value(nil)
 	self.scriptDebounceRef = Value(nil)
+
+	self.maxHandshakesRef = Value(nil)
+	self.maxReconnectionsRef = Value(nil)
+	self.reconnectionIntervalRef = Value(nil)
+
 	self.serviceListRef = Value(nil)
 	self.excludedParentsRef = Value(nil)
 
@@ -304,7 +320,7 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 								Text = Computed(function(use)
 									if not use(self.syncEnabled) then return "Connect" end
 									if use(self.handshakeComplete) then return "Disconnect" end
-									return "Connecting..."
+									return "Awaiting Daemon..."
 								end),
 								Size = UDim2.new(1, 0, 0, Theme.CompSizeY.Large),
 								Solid = true,
@@ -317,6 +333,13 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 								end,
 							}),
 							section("Behavior", {
+								labeledToggle("Auto Connect", self.autoConnect, function(newValue)
+									Config.AUTO_CONNECT = newValue
+									if self.callbacks.onAutoConnectChanged then
+										self.callbacks.onAutoConnectChanged(newValue)
+									end
+								end),
+								infoText("Automatically attempts to connect to Daemon."),
 								labeledToggle("Silent Mode", self.silentMode, function(newValue)
 									Config.SILENT_MODE = newValue
 									if self.callbacks.onSilentModeChanged then
@@ -347,13 +370,6 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 								}),
 							}),
 							section("Connection", {
-								labeledToggle("Auto Connect", self.autoConnect, function(newValue)
-									Config.AUTO_CONNECT = newValue
-									if self.callbacks.onAutoConnectChanged then
-										self.callbacks.onAutoConnectChanged(newValue)
-									end
-								end),
-								infoText("Automatically attempt to connect to the daemon on startup."),
 								labeledInput("WebSocket URL", self.wsUrlRef, {
 									Text = "ws://localhost:8080",
 									Finished = function(text)
@@ -385,6 +401,36 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 										if text == "" then return end
 										validateNumberInput(text, function(value)
 											self.callbacks.onConfigChanged("SCRIPT_CHANGE_DEBOUNCE", value)
+										end)
+									end,
+								}),
+							}),
+							section("Auto Connect", {
+								labeledInput("Maximum Handshake Attempts", self.maxHandshakesRef, {
+									Text = tostring(Config.MAX_HANDSHAKES),
+									Finished = function(text)
+										if text == "" then return end
+										validateNumberInput(text, function(value)
+											self.callbacks.onConfigChanged("MAX_HANDSHAKES", value)
+										end)
+									end,
+								}),
+								labeledInput("Maximum Reconnection Attempts", self.maxReconnectionsRef, {
+									Text = tostring(Config.MAX_RECONNECTIONS),
+									Placeholder = "-1 for infinite attempts",
+									Finished = function(text)
+										if text == "" then return end
+										validateNumberInput(text, function(value)
+											self.callbacks.onConfigChanged("MAX_RECONNECTIONS", value)
+										end, true)
+									end,
+								}),
+								labeledInput("Reconnection Interval (seconds)", self.reconnectionIntervalRef, {
+									Text = tostring(Config.RECONNECTION_INTERVAL),
+									Finished = function(text)
+										if text == "" then return end
+										validateNumberInput(text, function(value)
+											self.callbacks.onConfigChanged("RECONNECTION_INTERVAL", value)
 										end)
 									end,
 								}),
@@ -489,6 +535,7 @@ end
 function UI:UpdateConfig()
 	self = self :: AzulUI
 
+	self.autoConnect:set(Config.AUTO_CONNECT)
 	self.debugMode:set(Config.DEBUG_MODE)
 	self.silentMode:set(Config.SILENT_MODE)
 	self.settingsScopeValue:set(if self.settingsScope == Enums.scope.GLOBAL then "Global" else "Project")
@@ -506,6 +553,17 @@ function UI:UpdateConfig()
 	local scriptDebounceInput = peek(self.scriptDebounceRef)
 	if scriptDebounceInput then scriptDebounceInput.Text = tostring(Config.SCRIPT_CHANGE_DEBOUNCE) end
 
+
+	local maxConnectionsInput = peek(self.maxHandshakesRef)
+	if maxConnectionsInput then maxConnectionsInput.Text = tostring(Config.MAX_HANDSHAKESS) end
+
+	local maxReconnectionsInput = peek(self.maxReconnectionsRef)
+	if maxReconnectionsInput then maxReconnectionsInput.Text = tostring(Config.MAX_RECONNECTIONS) end
+
+	local reconnectionIntervalInput = peek(self.reconnectionIntervalRef)
+	if reconnectionIntervalInput then reconnectionIntervalInput.Text = tostring(Config.RECONNECTION_INTERVAL) end
+
+	
 	local serviceListInput = peek(self.serviceListRef)
 	if serviceListInput then serviceListInput.Text = table.concat(Config.SERVICE_LIST, ", ") end
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -1,6 +1,6 @@
 --!strict
 local AzulService = {}
-AzulService.VERSION = 43
+AzulService.VERSION = 44
 
 -- Services
 local ScriptEditorService = game:GetService("ScriptEditorService")
@@ -88,9 +88,7 @@ function AzulService.getOrCreatePath(pathSegments: { string }): Instance
 
 		if not nextNode then
 			if index == 1 then
-				local ok, service = pcall(function()
-					return game:GetService(segment)
-				end)
+				local ok, service = pcall(function() return game:GetService(segment) end)
 				if ok and service then nextNode = service end
 			end
 
@@ -112,9 +110,7 @@ function AzulService.isProtectedRobloxContainer(instance: Instance?): boolean
 	if not instance then return false end
 
 	-- Top-level services cannot be destroyed or reparented
-	local okService = pcall(function()
-		return game:GetService(instance.Name)
-	end)
+	local okService = pcall(function() return game:GetService(instance.Name) end)
 	if instance.Parent == game and okService then return true end
 
 	-- Certain StarterPlayer children are locked (StarterPlayerScripts, StarterCharacterScripts, StarterGear)
@@ -223,9 +219,7 @@ end
 --- Utility: set script source safely (handles large sources via ScriptEditorService)
 function AzulService.setScriptSource(scriptInstance: Script | LocalScript | ModuleScript, source: string)
 	local okUpdateSource, errUpdateSource = pcall(function()
-		ScriptEditorService:UpdateSourceAsync(scriptInstance, function(...)
-			return source
-		end)
+		ScriptEditorService:UpdateSourceAsync(scriptInstance, function(...) return source end)
 	end)
 
 	if not okUpdateSource then
@@ -290,9 +284,7 @@ function AzulService.applySnapshotInstances(
 	destination: { string }?
 ): (number, number, { [string]: Instance })
 	-- Sort instances by path length to make sure parents are created before children
-	table.sort(instances, function(a, b)
-		return #a.path < #b.path
-	end)
+	table.sort(instances, function(a, b) return #a.path < #b.path end)
 
 	--[=[
 		Extract MeshId from properties if present and valid. We need to do this before instance creation because MeshId is a special case that requires creating the MeshPart via InsertService with the content ID, and we want to avoid applying it as a normal property which would fail and log errors.
@@ -351,13 +343,15 @@ function AzulService.applySnapshotInstances(
 		targetName: string,
 		targetParent: Instance?
 	): MeshPart?
-		local okCreate, newMeshPart = pcall(function()
-			return InsertService:CreateMeshPartAsync(
-				meshData.meshId,
-				meshData.collisionFidelity,
-				meshData.renderFidelity
-			)
-		end)
+		local okCreate, newMeshPart = pcall(
+			function()
+				return InsertService:CreateMeshPartAsync(
+					meshData.meshId,
+					meshData.collisionFidelity,
+					meshData.renderFidelity
+				)
+			end
+		)
 		if not okCreate or not newMeshPart then return nil end
 
 		newMeshPart.Name = targetName
@@ -427,9 +421,7 @@ function AzulService.applySnapshotInstances(
 			local nextNode: Instance? = nil
 
 			if index == 1 then
-				local okService, service = pcall(function()
-					return game:GetService(segment)
-				end)
+				local okService, service = pcall(function() return game:GetService(segment) end)
 				if okService and service then nextNode = service end
 			end
 
@@ -451,9 +443,7 @@ function AzulService.applySnapshotInstances(
 		-- Get service candidate for the top-level node
 		local serviceCandidate: Instance? = nil
 		if #adjustedPath == 1 then
-			local okService, service = pcall(function()
-				return game:GetService(adjustedPath[1])
-			end)
+			local okService, service = pcall(function() return game:GetService(adjustedPath[1]) end)
 			if okService then serviceCandidate = service end
 		end
 
@@ -562,9 +552,7 @@ function AzulService.applySnapshotInstances(
 		if not instance and protectedContainerName then
 			local protectedParentName = lockedContainerParents[protectedContainerName]
 			if protectedParentName then
-				local okParent, protectedParent = pcall(function()
-					return game:GetService(protectedParentName)
-				end)
+				local okParent, protectedParent = pcall(function() return game:GetService(protectedParentName) end)
 				if okParent and protectedParent then
 					local protectedExisting = protectedParent:FindFirstChild(protectedContainerName)
 					if protectedExisting then instance = protectedExisting end
@@ -578,13 +566,15 @@ function AzulService.applySnapshotInstances(
 				local meshData = getMeshData(item.properties)
 				if meshData then
 					local content = Content.fromUri(meshData.meshId)
-					local okMesh, meshResult = pcall(function()
-						return InsertService:CreateMeshPartAsync(
-							meshData.meshId,
-							meshData.collisionFidelity,
-							meshData.renderFidelity
-						)
-					end)
+					local okMesh, meshResult = pcall(
+						function()
+							return InsertService:CreateMeshPartAsync(
+								meshData.meshId,
+								meshData.collisionFidelity,
+								meshData.renderFidelity
+							)
+						end
+					)
 
 					if okMesh and meshResult then
 						newInstance = meshResult
@@ -598,9 +588,7 @@ function AzulService.applySnapshotInstances(
 				end
 			end
 			if not newInstance then
-				local okNew, createdInstance = pcall(function()
-					return Instance.new(item.className)
-				end)
+				local okNew, createdInstance = pcall(function() return Instance.new(item.className) end)
 				if okNew and createdInstance then
 					newInstance = createdInstance
 				else
@@ -616,9 +604,7 @@ function AzulService.applySnapshotInstances(
 			created += 1
 		else
 			if parent and instance.Parent ~= parent and not AzulService.isProtectedRobloxContainer(instance) then
-				local okReparent = pcall(function()
-					instance.Parent = parent :: Instance
-				end)
+				local okReparent = pcall(function() instance.Parent = parent :: Instance end)
 				if not okReparent then
 					debugPrint(`Failed to reparent instance "{instance.Name}" ({instance.ClassName}) to target parent.`)
 				end
@@ -669,9 +655,7 @@ function AzulService.applySnapshotInstances(
 
 	for _, pending in ipairs(deferredPropertyApplications) do
 		Serializer.applySerializedProperties(pending.instance, pending.properties, {
-			resolveInstanceByGuid = function(guid: string): Instance?
-				return resolvedInstancesByGuid[guid]
-			end,
+			resolveInstanceByGuid = function(guid: string): Instance? return resolvedInstancesByGuid[guid] end,
 			resolveInstanceByPath = function(pathSegments: { string }): Instance?
 				return findInstanceByPath(pathSegments)
 			end,
@@ -690,9 +674,7 @@ function AzulService.findPushConfigModule(pushConfigPath: { string }): ModuleScr
 	local current: Instance = game
 	for index, segment in ipairs(pushConfigPath) do
 		if index == 1 then
-			local ok, service = pcall(function()
-				return game:GetService(segment)
-			end)
+			local ok, service = pcall(function() return game:GetService(segment) end)
 			if not ok or not service then return nil end
 			current = service
 		else

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -192,7 +192,7 @@ function AzulService.instanceToData(
 		parentGuid = parentGuid,
 	}
 
-	if AzulService.isScript(instance) then data.source = (instance :: Script).Source end
+	if AzulService.isScript(instance) then data.source = ScriptEditorService:GetEditorSource(instance) end
 
 	if options and options.includeProperties then
 		local properties = Serializer.collectSerializedProperties(instance, {

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
@@ -114,6 +114,11 @@ plugin.Unloading:Connect(function()
 	session:stopSync()
 end)
 
-session:infoPrint("Plugin loaded. Click on the 'Azul' button to connect.")
+if Config.AUTO_CONNECT then
+	session:startSync()
+else
+	session:infoPrint("Plugin loaded. Click on the 'Azul' button to connect.")
+end
+
 session:debugPrint("Debug mode is enabled!")
 session:debugPrint(`Service list type is set to: "{Config.LIST_TYPE}"`)

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
@@ -140,6 +140,17 @@ local uiCallbacks: UI.CallbackFunctions = {
 		)
 		Config[key] = value
 		if key == "SERVICE_LIST" then session:rebuildServiceSet() end
+		if key == "AUTO_CONNECT" then
+			if value then
+				startWatchdog()
+			else
+				if connectionWatchdog then
+					task.cancel(connectionWatchdog)
+					connectionWatchdog = nil
+				end
+				if session.syncEnabled and not session.handshakeComplete then session:stopSync() end
+			end
+		end
 	end,
 
 	onSettingsScopeChanged = function(newScope)

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
@@ -32,104 +32,30 @@ local settingsStore = SettingsStore.new(plugin, Config, Enums.scope, {
 settingsStore:loadSettings()
 
 local session = SyncSession.new(plugin, settingsStore, Config)
-local connectionWatchdog: thread? = nil
-
---[=[
-    Watchdog for Auto Connection
-]=]
-local function startWatchdog()
-    if connectionWatchdog then
-        task.cancel(connectionWatchdog)
-        connectionWatchdog = nil
-    end
-
-    connectionWatchdog = task.spawn(function()
-        local attempts = 0
-        session:debugPrint("Watchdog started.")
-
-        while true do
-            -- 1. Exit if Auto-Connect is disabled
-            if not Config.AUTO_CONNECT then 
-                session:debugPrint("Watchdog terminating: AUTO_CONNECT is false.")
-                break 
-            end
-
-            -- 2. If we aren't connected and haven't even started syncing yet
-            if not session.syncEnabled and not session.handshakeComplete then
-                session:debugPrint(`Watchdog: Attempting auto-connect... (Attempt {attempts + 1})`)
-                session:startSync()
-            end
-
-            -- 3. Wait for the result of the attempt
-            -- We poll until either handshake succeeds OR the session shuts down (failure)
-            local timeout = 0
-            while session.syncEnabled and not session.handshakeComplete and timeout < 10 do
-                task.wait(1)
-                timeout += 1
-            end
-
-            if session.handshakeComplete then
-                attempts = 0
-                session:debugPrint("Watchdog: Connection Succeeded.")
-                
-                -- Idle here as long as we are connected
-                repeat task.wait(2) until not session.handshakeComplete or not Config.AUTO_CONNECT
-            else
-                -- Failed to handshake or session stopped
-                attempts += 1
-                session:debugPrint(`Watchdog: Attempt {attempts} failed.`)
-
-                if Config.MAX_RECONNECTIONS ~= -1 and attempts >= Config.MAX_RECONNECTIONS then
-                    session:infoPrint(`Auto-connect: Reached max attempts ({Config.MAX_RECONNECTIONS}). Stopping.`)
-                    break
-                end
-
-                -- Interval wait
-                task.wait(Config.RECONNECTION_INTERVAL or 5)
-            end
-            
-            task.wait(.1)
-        end
-        
-        connectionWatchdog = nil
-    end)
-end
 
 --[=[
     UI Callback Handlers
 ]=]
 local uiCallbacks: UI.CallbackFunctions = {
 	onStartSync = function()
+		-- If the auto-connect runner is active, stop it while user triggers manual start.
+		session:stopAutoConnect()
 
-		-- Stop watchdog (if ever)
-		if connectionWatchdog then
-			task.cancel(connectionWatchdog)
-			connectionWatchdog = nil
-		end
-		
 		session:startSync()
 
-		-- If Auto Connect is on, restart the watchdog to monitor the new connection
-		if Config.AUTO_CONNECT then
-			startWatchdog()
-		end
+		-- If Auto Connect still requested, restart the auto-connect runner to monitor
+		if Config.AUTO_CONNECT then session:startAutoConnect() end
 	end,
 
-	onStopSync = function()
-		session:stopSync()
-	end,
+	onStopSync = function() session:stopSync() end,
 
 	onAutoConnectChanged = function(newValue: boolean)
 		Config.AUTO_CONNECT = newValue
 		session:debugPrint(`Auto Connect changed: {newValue}`)
-		
 		if newValue then
-			startWatchdog()
-		else 
-			if connectionWatchdog then
-				task.cancel(connectionWatchdog)
-				connectionWatchdog = nil
-			end
+			session:startAutoConnect()
+		else
+			session:stopAutoConnect()
 			if session.syncEnabled and not session.handshakeComplete then session:stopSync() end
 		end
 	end,
@@ -142,20 +68,15 @@ local uiCallbacks: UI.CallbackFunctions = {
 		if key == "SERVICE_LIST" then session:rebuildServiceSet() end
 		if key == "AUTO_CONNECT" then
 			if value then
-				startWatchdog()
+				session:startAutoConnect()
 			else
-				if connectionWatchdog then
-					task.cancel(connectionWatchdog)
-					connectionWatchdog = nil
-				end
+				session:stopAutoConnect()
 				if session.syncEnabled and not session.handshakeComplete then session:stopSync() end
 			end
 		end
 	end,
 
-	onSettingsScopeChanged = function(newScope)
-		session:onSettingsScopeChanged(newScope)
-	end,
+	onSettingsScopeChanged = function(newScope) session:onSettingsScopeChanged(newScope) end,
 
 	onSourcemapReload = function()
 		session:infoPrint("Reloading sourcemap...")
@@ -164,15 +85,13 @@ local uiCallbacks: UI.CallbackFunctions = {
 }
 
 local uiHelpers = {
-	rebuildServiceSet = function()
-		session:rebuildServiceSet()
-	end,
-	
+	rebuildServiceSet = function() session:rebuildServiceSet() end,
+
 	openPlaceConfig = function()
 		local ScriptEditorService = game:GetService("ScriptEditorService")
 		local ServerStorage = game:GetService("ServerStorage")
 		local azulFolder = ServerStorage:FindFirstChild("Azul") :: Folder
-		
+
 		if not azulFolder then
 			local newAzulFolder = Instance.new("Folder")
 			newAzulFolder.Name = "Azul"
@@ -215,16 +134,14 @@ end
 
 -- Plugin Lifecycle
 plugin.Unloading:Connect(function()
-	if connectionWatchdog then
-		task.cancel(connectionWatchdog)
-	end
+	session:stopAutoConnect()
 	settingsStore:saveSettings()
 	settingsStore:saveSelectedScope()
 	session:stopSync()
 end)
 
 if Config.AUTO_CONNECT then
-	startWatchdog()
+	session:startAutoConnect()
 else
 	session:infoPrint("Plugin loaded. Click on the 'Azul' button to connect.")
 end

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau
@@ -13,36 +13,127 @@ if RunService:IsRunning() then return end
 
 local pluginParent = script.Parent
 if not pluginParent then return end
-local azulPluginFolder = pluginParent.Parent
-if not azulPluginFolder then return end
 
+-- Modules
 local UI = require("./UI")
 local Config = require("./Config")
 local Enums = require("./Enums")
 local SettingsStore = require("./SettingsStore")
 local SyncSession = require("./SyncSession")
 
+-- UI Apps
 local azulApp = require("./App/UI")
 local azulLegacyUI = require("./UI")
 
-local function debugPrint(...)
-	if Config.DEBUG_MODE then print("[🐛 Azul]", ...) end
-end
-
+-- State Management
 local settingsStore = SettingsStore.new(plugin, Config, Enums.scope, {
 	defaultScope = Enums.scope.GLOBAL,
 })
 settingsStore:loadSettings()
 
 local session = SyncSession.new(plugin, settingsStore, Config)
+local connectionWatchdog: thread? = nil
 
+--[=[
+    Watchdog for Auto Connection
+]=]
+local function startWatchdog()
+    if connectionWatchdog then
+        task.cancel(connectionWatchdog)
+        connectionWatchdog = nil
+    end
+
+    connectionWatchdog = task.spawn(function()
+        local attempts = 0
+        session:debugPrint("Watchdog started.")
+
+        while true do
+            -- 1. Exit if Auto-Connect is disabled
+            if not Config.AUTO_CONNECT then 
+                session:debugPrint("Watchdog terminating: AUTO_CONNECT is false.")
+                break 
+            end
+
+            -- 2. If we aren't connected and haven't even started syncing yet
+            if not session.syncEnabled and not session.handshakeComplete then
+                session:debugPrint(`Watchdog: Attempting auto-connect... (Attempt {attempts + 1})`)
+                session:startSync()
+            end
+
+            -- 3. Wait for the result of the attempt
+            -- We poll until either handshake succeeds OR the session shuts down (failure)
+            local timeout = 0
+            while session.syncEnabled and not session.handshakeComplete and timeout < 10 do
+                task.wait(1)
+                timeout += 1
+            end
+
+            if session.handshakeComplete then
+                attempts = 0
+                session:debugPrint("Watchdog: Connection Succeeded.")
+                
+                -- Idle here as long as we are connected
+                repeat task.wait(2) until not session.handshakeComplete or not Config.AUTO_CONNECT
+            else
+                -- Failed to handshake or session stopped
+                attempts += 1
+                session:debugPrint(`Watchdog: Attempt {attempts} failed.`)
+
+                if Config.MAX_RECONNECTIONS ~= -1 and attempts >= Config.MAX_RECONNECTIONS then
+                    session:infoPrint(`Auto-connect: Reached max attempts ({Config.MAX_RECONNECTIONS}). Stopping.`)
+                    break
+                end
+
+                -- Interval wait
+                task.wait(Config.RECONNECTION_INTERVAL or 5)
+            end
+            
+            task.wait(.1)
+        end
+        
+        connectionWatchdog = nil
+    end)
+end
+
+--[=[
+    UI Callback Handlers
+]=]
 local uiCallbacks: UI.CallbackFunctions = {
 	onStartSync = function()
+
+		-- Stop watchdog (if ever)
+		if connectionWatchdog then
+			task.cancel(connectionWatchdog)
+			connectionWatchdog = nil
+		end
+		
 		session:startSync()
+
+		-- If Auto Connect is on, restart the watchdog to monitor the new connection
+		if Config.AUTO_CONNECT then
+			startWatchdog()
+		end
 	end,
+
 	onStopSync = function()
 		session:stopSync()
 	end,
+
+	onAutoConnectChanged = function(newValue: boolean)
+		Config.AUTO_CONNECT = newValue
+		session:debugPrint(`Auto Connect changed: {newValue}`)
+		
+		if newValue then
+			startWatchdog()
+		else 
+			if connectionWatchdog then
+				task.cancel(connectionWatchdog)
+				connectionWatchdog = nil
+			end
+			if session.syncEnabled and not session.handshakeComplete then session:stopSync() end
+		end
+	end,
+
 	onConfigChanged = function(key, value)
 		session:debugPrint(
 			`Config {key} updated to: {if type(value) == "table" then table.concat(value, ", ") else tostring(value)}`
@@ -50,9 +141,11 @@ local uiCallbacks: UI.CallbackFunctions = {
 		Config[key] = value
 		if key == "SERVICE_LIST" then session:rebuildServiceSet() end
 	end,
+
 	onSettingsScopeChanged = function(newScope)
 		session:onSettingsScopeChanged(newScope)
 	end,
+
 	onSourcemapReload = function()
 		session:infoPrint("Reloading sourcemap...")
 		session:reloadSourcemap()
@@ -63,12 +156,13 @@ local uiHelpers = {
 	rebuildServiceSet = function()
 		session:rebuildServiceSet()
 	end,
+	
 	openPlaceConfig = function()
 		local ScriptEditorService = game:GetService("ScriptEditorService")
 		local ServerStorage = game:GetService("ServerStorage")
 		local azulFolder = ServerStorage:FindFirstChild("Azul") :: Folder
+		
 		if not azulFolder then
-			debugPrint("Place doesn't have an 'Azul' folder in ServerStorage, creating one...")
 			local newAzulFolder = Instance.new("Folder")
 			newAzulFolder.Name = "Azul"
 			newAzulFolder.Parent = ServerStorage
@@ -77,18 +171,15 @@ local uiHelpers = {
 
 		local azulDaemonSettings = azulFolder:FindFirstChild("Config") :: ModuleScript
 		if not azulDaemonSettings then
-			debugPrint("Place doesn't have a 'Config' ModuleScript in the 'Azul' folder, creating one...")
 			local newConfigModule = Instance.new("ModuleScript")
 			newConfigModule.Name = "Config"
 			newConfigModule.Source = [[
 -- Per-place Daemon configuration
--- This file is sent to the Daemon when it connects, and can be used to specify settings for this specific Place, such as push mappings.
-
--- More info about the format:
+-- This file is sent to the Daemon when it connects.
 -- https://azul-docs.vercel.app/advanced-usage/#per-place-daemon-configuration
 
 return {}
-			]]
+]]
 			newConfigModule.Parent = azulFolder
 			azulDaemonSettings = newConfigModule
 		end
@@ -97,6 +188,9 @@ return {}
 	end,
 }
 
+--[=[
+    Initialization
+]=]
 local USE_LEGACY_UI = false
 
 if not USE_LEGACY_UI then
@@ -108,14 +202,18 @@ else
 	session:setUI(azulUI)
 end
 
+-- Plugin Lifecycle
 plugin.Unloading:Connect(function()
+	if connectionWatchdog then
+		task.cancel(connectionWatchdog)
+	end
 	settingsStore:saveSettings()
 	settingsStore:saveSelectedScope()
 	session:stopSync()
 end)
 
 if Config.AUTO_CONNECT then
-	session:startSync()
+	startWatchdog()
 else
 	session:infoPrint("Plugin loaded. Click on the 'Azul' button to connect.")
 end

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
@@ -24,6 +24,7 @@ configTable = {
 		"Workspace.Surface Converter Storage", -- Folder managed by "Surface Converter" plugin. We don't need to track it.
 	},
 
+	AUTO_CONNECT = false,
 	DEBUG_MODE = false,
 	SILENT_MODE = false,
 }

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
@@ -5,7 +5,7 @@ configTable = {
 
 	--// Auto-Reconnect Settings
 	MAX_HANDSHAKES = 5, --// Maximum handshake attempts per connection
-	MAX_RECONNECTIONS = -1, --// Maximum total reconnection attempts before giving up
+	MAX_RECONNECTIONS = -1, --// Maximum total reconnection attempts before giving up (-1 for infinite)
 	RECONNECTION_INTERVAL = 5,
 	
 	HEARTBEAT_INTERVAL = 30,

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
@@ -2,6 +2,12 @@ local Enums = require("./Enums")
 
 configTable = {
 	WS_URL = "ws://localhost:8080",
+
+	--// Auto-Reconnect Settings
+	MAX_HANDSHAKES = 5, --// Maximum handshake attempts per connection
+	MAX_RECONNECTIONS = -1, --// Maximum total reconnection attempts before giving up
+	RECONNECTION_INTERVAL = 5,
+	
 	HEARTBEAT_INTERVAL = 30,
 	BATCH_IDLE_WINDOW = 0.1,
 	SCRIPT_CHANGE_DEBOUNCE = 0.35,

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -51,7 +51,7 @@ export type SyncSession = {
 	handshakeComplete: boolean,
 
 	-- Methods
-	startSync: (self: SyncSession) -> (),
+	startSync: (self: SyncSession, suppressInfo: boolean?) -> (),
 	stopSync: (self: SyncSession, dontRelayDisconnect: boolean?) -> (),
 	reloadSourcemap: (self: SyncSession) -> (),
 	onSettingsScopeChanged: (self: SyncSession, newScope: string) -> (),
@@ -65,6 +65,7 @@ export type SyncSession = {
 	-- Auto-connect helpers
 	_autoConnectThread: thread?,
 	_handshakeBindable: BindableEvent?,
+	_suppressAutoConnectLogs: boolean?,
 }
 
 -- Constants
@@ -747,13 +748,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 	function self:reloadSourcemap() sendFullSnapshot() end
 
-	function self:startSync()
+	function self:startSync(suppressInfo: boolean?)
 		if self.syncEnabled then
 			warn(`[Azul::{script}]: A Sync Session already active!`)
 			return
 		end
-
-		self:infoPrint("Starting sync...")
+		local suppress = suppressInfo == true
+		self._suppressAutoConnectLogs = suppress
+		if not suppress then self:infoPrint("Starting sync...") end
 		self.syncEnabled = true
 		self.batchingEnabled = false
 		self.batchFlushToken += 1
@@ -773,7 +775,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 
 		self.wsClient:on("connect", function()
-			self:infoPrint(`Connected to WebSocket at: {self.config.WS_URL}`)
+			if not self._suppressAutoConnectLogs then
+				self:infoPrint(`Connected to WebSocket at: {self.config.WS_URL}`)
+			end
 			local handshakeResult = tryHandshake()
 
 			if not handshakeResult then
@@ -889,6 +893,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 		self.connections = {}
 
+		self._suppressAutoConnectLogs = false
 		self:infoPrint("Sync stopped")
 	end
 
@@ -911,13 +916,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		if self._autoConnectThread then return end
 		self._autoConnectThread = task.spawn(function()
 			local attempts = 0
+			self:infoPrint("Auto-connect enabled")
 			self:debugPrint("AutoConnect: watchdog started")
 
 			while self.config.AUTO_CONNECT do
 				-- If not syncing, attempt to start
 				if not self.syncEnabled and not self.handshakeComplete then
 					self:debugPrint("AutoConnect: starting sync...")
-					self:startSync()
+					self:startSync(true)
 				end
 
 				-- Wait for handshake or failure

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -59,6 +59,12 @@ export type SyncSession = {
 	debugPrint: (self: SyncSession, ...any) -> (),
 	infoPrint: (self: SyncSession, ...any) -> (),
 	rebuildServiceSet: (self: SyncSession) -> (),
+	startAutoConnect: (self: SyncSession) -> (),
+	stopAutoConnect: (self: SyncSession) -> (),
+
+	-- Auto-connect helpers
+	_autoConnectThread: thread?,
+	_handshakeBindable: BindableEvent?,
 }
 
 -- Constants
@@ -86,13 +92,9 @@ function SyncSession:infoPrint(...)
 	print(`[Azul]: `, ...)
 end
 
-function SyncSession:rebuildServiceSet()
-	AzulService.rebuildServiceSet(self.serviceSet)
-end
+function SyncSession:rebuildServiceSet() AzulService.rebuildServiceSet(self.serviceSet) end
 
-function SyncSession:setUI(ui)
-	self.ui = ui
-end
+function SyncSession:setUI(ui) self.ui = ui end
 
 function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsStore, config: any): SyncSession
 	local self = (setmetatable({}, SyncSession) :: any) :: SyncSession
@@ -127,6 +129,10 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	self.serviceSet = {}
 	self.handshakeComplete = false
 
+	-- Auto-connect helpers
+	self._autoConnectThread = nil
+	self._handshakeBindable = Instance.new("BindableEvent")
+
 	self:rebuildServiceSet()
 
 	local function shouldIncludeInSnapshot(instance)
@@ -156,9 +162,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 
 		self:debugPrint(`Sending message: {message.type}`)
-		local encodeOk, encodedOrErr = pcall(function()
-			return HttpService:JSONEncode(message)
-		end)
+		local encodeOk, encodedOrErr = pcall(function() return HttpService:JSONEncode(message) end)
 		if not encodeOk then
 			warn(`[Azul]: Cannot JSON-encode outbound message (type: {tostring(message.type)}): {encodedOrErr}`)
 			return false
@@ -344,9 +348,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	local function attachListeners(instance)
 		if not shouldIncludeInSnapshot(instance) then return end
 
-		local nameConnnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
-			sendInstanceUpdateDedup(instance)
-		end)
+		local nameConnnection = instance
+			:GetPropertyChangedSignal("Name")
+			:Connect(function() sendInstanceUpdateDedup(instance) end)
 		table.insert(self.connections, nameConnnection)
 
 		local parentConnection = instance:GetPropertyChangedSignal("Parent"):Connect(function()
@@ -366,9 +370,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	local function wipeChildren(container: Instance)
 		for _, child in ipairs(container:GetChildren()) do
 			if AzulService.isProtectedRobloxContainer(child) then continue end
-			local ok, err = pcall(function()
-				child:Destroy()
-			end)
+			local ok, err = pcall(function() child:Destroy() end)
 			if not ok then warn(`[Azul]: Cannot destroy '{child.Name}': {err}`) end
 		end
 	end
@@ -387,9 +389,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		for rootName in pairs(rootsSeen) do
 			local rootInstance: Instance? = nil
 
-			local okService, service = pcall(function()
-				return game:GetService(rootName)
-			end)
+			local okService, service = pcall(function() return game:GetService(rootName) end)
 			if okService and service then
 				rootInstance = service
 			else
@@ -397,9 +397,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end
 
 			if rootInstance then
-				local ok, err = pcall(function()
-					wipeChildren(rootInstance)
-				end)
+				local ok, err = pcall(function() wipeChildren(rootInstance) end)
 				if not ok then warn(`[Azul]: Failed to wipe children for root container '{rootName}': {err}`) end
 			else
 				warn(`[Azul]: Destructive build could not find root container '{rootName}', skipping wipe`)
@@ -585,6 +583,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			self.handshakeComplete = true
 			self:debugPrint("Handshake implicitly satisfied by daemon message")
 			if self.ui then self.ui:UpdateHandshakeState(true) end
+			if self._handshakeBindable then pcall(function() self._handshakeBindable:Fire() end) end
 		end
 	end
 
@@ -645,9 +644,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			setOutboundSuppressed(false)
 			if not ok then warn("[Azul]: Error applying build snapshot: ", err) end
 
-			task.delay(0.5, function()
-				self:stopSync()
-			end)
+			task.delay(0.5, function() self:stopSync() end)
 		elseif message.type == "pushSnapshot" then
 			implicitHandshake()
 			self:infoPrint("Applying push snapshot from daemon")
@@ -686,9 +683,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			setOutboundSuppressed(false)
 			if not ok then warn("[Azul]: Error applying push snapshot", err) end
 
-			task.delay(0.5, function()
-				self:stopSync()
-			end)
+			task.delay(0.5, function() self:stopSync() end)
 		elseif message.type == "requestPushConfig" then
 			sendDaemonConfig(true)
 		elseif message.type == "handshakeAck" then
@@ -698,6 +693,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				self:infoPrint("Handshake with Daemon successful")
 				sendDaemonConfig()
 				if self.ui then self.ui:UpdateHandshakeState(true) end
+				if self._handshakeBindable then pcall(function() self._handshakeBindable:Fire() end) end
 			end
 		elseif message.type == "daemonDisconnect" then
 			self:infoPrint("Daemon is shutting down; disconnecting plugin")
@@ -739,11 +735,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end
 
 			tries += 1
-			
+
 			--// Otherwise would bloat the console
-			if not self.config.AUTO_CONNECT then
-				warn(`[Azul]: Handshake attempt {tries} failed, retrying...`)
-			end
+			if not self.config.AUTO_CONNECT then warn(`[Azul]: Handshake attempt {tries} failed, retrying...`) end
 
 		--self.wsClient:reconnect()
 		until tries >= HANDSHAKE_MAX_RETRIES
@@ -751,9 +745,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		return self.handshakeComplete
 	end
 
-	function self:reloadSourcemap()
-		sendFullSnapshot()
-	end
+	function self:reloadSourcemap() sendFullSnapshot() end
 
 	function self:startSync()
 		if self.syncEnabled then
@@ -791,18 +783,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end
 		end)
 
-		self.wsClient:on("message", function(message)
-			processMessage(message)
-		end)
+		self.wsClient:on("message", function(message) processMessage(message) end)
 
 		self.wsClient:on("disconnect", function()
 			self:infoPrint("Disconnected from daemon")
 			self:stopSync()
 		end)
 
-		self.wsClient:on("error", function(error)
-			warn("[Azul]: Connection error:", error)
-		end)
+		self.wsClient:on("error", function(error) warn("[Azul]: Connection error:", error) end)
 
 		local connected = self.wsClient:connect()
 		if not connected then
@@ -916,6 +904,76 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 		local scopeLabel = if self.settingsStore:getScope() == Enums.scope.GLOBAL then "Global" else "Project"
 		self:infoPrint(`Settings scope set to {scopeLabel}`)
+	end
+
+	-- Auto-connect control: run a background task to attempt connects and honor config
+	function self:startAutoConnect()
+		if self._autoConnectThread then return end
+		self._autoConnectThread = task.spawn(function()
+			local attempts = 0
+			self:debugPrint("AutoConnect: watchdog started")
+
+			while self.config.AUTO_CONNECT do
+				-- If not syncing, attempt to start
+				if not self.syncEnabled and not self.handshakeComplete then
+					self:debugPrint("AutoConnect: starting sync...")
+					self:startSync()
+				end
+
+				-- Wait for handshake or failure
+				local handshakeFired = false
+				local conn
+				if self._handshakeBindable then
+					conn = self._handshakeBindable.Event:Connect(function() handshakeFired = true end)
+				end
+
+				local waitCount = 0
+				while
+					self.syncEnabled
+					and not self.handshakeComplete
+					and waitCount < safeGetNumber(self.config.MAX_HANDSHAKES, 5)
+				do
+					task.wait(1)
+					waitCount += 1
+					if handshakeFired then break end
+				end
+
+				if conn then conn:Disconnect() end
+
+				if self.handshakeComplete then
+					attempts = 0
+					self:debugPrint("AutoConnect: connection succeeded")
+					-- Idle while connected
+					repeat
+						task.wait(2)
+					until not self.handshakeComplete or not self.config.AUTO_CONNECT
+				else
+					attempts += 1
+					self:debugPrint(`AutoConnect: attempt {attempts} failed`)
+					if self.config.MAX_RECONNECTIONS ~= -1 and attempts >= self.config.MAX_RECONNECTIONS then
+						self:infoPrint(
+							`Auto-connect: Reached max attempts ({self.config.MAX_RECONNECTIONS}). Stopping.`
+						)
+						break
+					end
+					-- Wait before next attempt
+					task.wait(safeGetNumber(self.config.RECONNECTION_INTERVAL, 5))
+				end
+				if not self.config.AUTO_CONNECT then break end
+				-- minor yield to avoid tight loop
+				task.wait(0.1)
+			end
+
+			self._autoConnectThread = nil
+			self:debugPrint("AutoConnect: watchdog stopped")
+		end)
+	end
+
+	function self:stopAutoConnect()
+		if not self._autoConnectThread then return end
+		local ok, err = pcall(function() task.cancel(self._autoConnectThread) end)
+		self._autoConnectThread = nil
+		if not ok then warn("AutoConnect: failed to cancel thread:", err) end
 	end
 
 	return self :: SyncSession

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -79,23 +79,33 @@ local PUSH_CONFIG_PATH = {
 local INITIAL_BATCH_INTERVAL = 0.2 -- Seconds between outbound batch flushes
 
 local function safeGetNumber(value: any, default: number)
-	if type(value) == "number" and value > 0 then return value end
+	if type(value) == "number" and value > 0 then
+		return value
+	end
 	return default
 end
 
 function SyncSession:debugPrint(...)
-	if self.config.SILENT_MODE or not self.config.DEBUG_MODE then return end
+	if self.config.SILENT_MODE or not self.config.DEBUG_MODE then
+		return
+	end
 	print(`[🐛 Azul::{script}]:`, ...)
 end
 
 function SyncSession:infoPrint(...)
-	if self.config.SILENT_MODE then return end
+	if self.config.SILENT_MODE then
+		return
+	end
 	print(`[Azul]: `, ...)
 end
 
-function SyncSession:rebuildServiceSet() AzulService.rebuildServiceSet(self.serviceSet) end
+function SyncSession:rebuildServiceSet()
+	AzulService.rebuildServiceSet(self.serviceSet)
+end
 
-function SyncSession:setUI(ui) self.ui = ui end
+function SyncSession:setUI(ui)
+	self.ui = ui
+end
 
 function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsStore, config: any): SyncSession
 	local self = (setmetatable({}, SyncSession) :: any) :: SyncSession
@@ -137,12 +147,16 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	self:rebuildServiceSet()
 
 	local function shouldIncludeInSnapshot(instance)
-		if not instance then return false end
+		if not instance then
+			return false
+		end
 		return not AzulService.isExcluded(instance, self.serviceSet)
 	end
 
 	local function sendMessage(messageTypeOrPayload: string | { any }, data: any?)
-		if not self.wsClient or not self.wsClient.connected then return false end
+		if not self.wsClient or not self.wsClient.connected then
+			return false
+		end
 
 		local message
 
@@ -163,7 +177,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 
 		self:debugPrint(`Sending message: {message.type}`)
-		local encodeOk, encodedOrErr = pcall(function() return HttpService:JSONEncode(message) end)
+		local encodeOk, encodedOrErr = pcall(function()
+			return HttpService:JSONEncode(message)
+		end)
 		if not encodeOk then
 			warn(`[Azul]: Cannot JSON-encode outbound message (type: {tostring(message.type)}): {encodedOrErr}`)
 			return false
@@ -212,7 +228,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		table.clear(self.pendingInstanceUpdates)
 		table.clear(self.pendingDeletes)
 
-		if #messages == 0 then return end
+		if #messages == 0 then
+			return
+		end
 
 		if self.batchingEnabled and #messages > 1 then
 			if #messages > 200 then
@@ -229,28 +247,40 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function scheduleBatchFlush()
-		if not self.batchingEnabled then return end
+		if not self.batchingEnabled then
+			return
+		end
 
 		self.batchFlushToken += 1
 		local token = self.batchFlushToken
 
 		task.delay(safeGetNumber(self.config.BATCH_IDLE_WINDOW, 0.1), function()
-			if token ~= self.batchFlushToken then return end
+			if token ~= self.batchFlushToken then
+				return
+			end
 			flushOutboundQueues()
 		end)
 	end
 
 	local function queueInstanceUpdate(data)
-		if self.suppressOutbound or not self.syncEnabled then return end
-		if not data or not data.guid then return end
+		if self.suppressOutbound or not self.syncEnabled then
+			return
+		end
+		if not data or not data.guid then
+			return
+		end
 
 		self.pendingInstanceUpdates[data.guid] = data
 		scheduleBatchFlush()
 	end
 
 	local function queueScriptChange(payload)
-		if self.suppressOutbound or not self.syncEnabled then return end
-		if not payload or not payload.guid then return end
+		if self.suppressOutbound or not self.syncEnabled then
+			return
+		end
+		if not payload or not payload.guid then
+			return
+		end
 
 		self.pendingScriptChangeReady[payload.guid] = false
 		self.pendingScriptChanges[payload.guid] = payload
@@ -259,9 +289,15 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		self.scriptChangeDebounceTokenByGuid[payload.guid] = token
 
 		task.delay(safeGetNumber(self.config.SCRIPT_CHANGE_DEBOUNCE, 0.35), function()
-			if not self.syncEnabled or self.suppressOutbound then return end
-			if self.scriptChangeDebounceTokenByGuid[payload.guid] ~= token then return end
-			if not self.pendingScriptChanges[payload.guid] then return end
+			if not self.syncEnabled or self.suppressOutbound then
+				return
+			end
+			if self.scriptChangeDebounceTokenByGuid[payload.guid] ~= token then
+				return
+			end
+			if not self.pendingScriptChanges[payload.guid] then
+				return
+			end
 
 			self.pendingScriptChangeReady[payload.guid] = true
 			scheduleBatchFlush()
@@ -269,8 +305,12 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function queueDeletion(guid: string)
-		if self.suppressOutbound or not self.syncEnabled then return end
-		if not guid or guid == "" then return end
+		if self.suppressOutbound or not self.syncEnabled then
+			return
+		end
+		if not guid or guid == "" then
+			return
+		end
 
 		self.pendingDeletes[guid] = true
 		scheduleBatchFlush()
@@ -288,7 +328,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function sendInstanceUpdateDedup(instance)
-		if self.suppressOutbound or not self.syncEnabled then return end
+		if self.suppressOutbound or not self.syncEnabled then
+			return
+		end
 
 		local data = AzulService.instanceToDataDedup(
 			instance,
@@ -297,7 +339,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			self.usedGuids,
 			self.lastInstanceUpdate
 		)
-		if not data then return end
+		if not data then
+			return
+		end
 
 		local guid = data.guid
 		self.trackedInstances[instance] = guid
@@ -307,13 +351,19 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function shouldSync(instance)
-		if not instance then return false end
-		if not AzulService.isScript(instance) then return false end
+		if not instance then
+			return false
+		end
+		if not AzulService.isScript(instance) then
+			return false
+		end
 		return not AzulService.isExcluded(instance, self.serviceSet)
 	end
 
 	local function onScriptChanged(changedScript: Script | LocalScript | ModuleScript)
-		if self.suppressOutbound or not shouldSync(changedScript) then return end
+		if self.suppressOutbound or not shouldSync(changedScript) then
+			return
+		end
 
 		local guid = AzulService.getOrCreateGUID(changedScript, self.trackedInstances, self.guidMap, self.usedGuids)
 
@@ -326,7 +376,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			return
 		end
 
-		if self.applyingPatch then return end
+		if self.applyingPatch then
+			return
+		end
 
 		local lastPatch = self.lastPatchTime[guid] or 0
 		local now = tick()
@@ -336,7 +388,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 
 		local path = AzulService.getInstancePath(changedScript)
-		if not path then return end
+		if not path then
+			return
+		end
 
 		queueScriptChange({
 			guid = guid,
@@ -347,22 +401,28 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function attachListeners(instance)
-		if not shouldIncludeInSnapshot(instance) then return end
+		if not shouldIncludeInSnapshot(instance) then
+			return
+		end
 
-		local nameConnnection = instance
-			:GetPropertyChangedSignal("Name")
-			:Connect(function() sendInstanceUpdateDedup(instance) end)
+		local nameConnnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
+			sendInstanceUpdateDedup(instance)
+		end)
 		table.insert(self.connections, nameConnnection)
 
 		local parentConnection = instance:GetPropertyChangedSignal("Parent"):Connect(function()
-			if instance.Parent == nil then return end
+			if instance.Parent == nil then
+				return
+			end
 			sendInstanceUpdateDedup(instance)
 		end)
 		table.insert(self.connections, parentConnection)
 
 		if AzulService.isScript(instance) then
 			local sourceConnection = (instance :: Script):GetPropertyChangedSignal("Source"):Connect(function()
-				if self.syncEnabled then onScriptChanged(instance :: Script) end
+				if self.syncEnabled then
+					onScriptChanged(instance :: Script)
+				end
 			end)
 			table.insert(self.connections, sourceConnection)
 		end
@@ -370,9 +430,15 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 	local function wipeChildren(container: Instance)
 		for _, child in ipairs(container:GetChildren()) do
-			if AzulService.isProtectedRobloxContainer(child) then continue end
-			local ok, err = pcall(function() child:Destroy() end)
-			if not ok then warn(`[Azul]: Cannot destroy '{child.Name}': {err}`) end
+			if AzulService.isProtectedRobloxContainer(child) then
+				continue
+			end
+			local ok, err = pcall(function()
+				child:Destroy()
+			end)
+			if not ok then
+				warn(`[Azul]: Cannot destroy '{child.Name}': {err}`)
+			end
 		end
 	end
 
@@ -383,14 +449,18 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			local path = item.path
 			if type(path) == "table" and #path >= 1 then
 				local rootName = path[1]
-				if type(rootName) == "string" and rootName ~= "" then rootsSeen[rootName] = true end
+				if type(rootName) == "string" and rootName ~= "" then
+					rootsSeen[rootName] = true
+				end
 			end
 		end
 
 		for rootName in pairs(rootsSeen) do
 			local rootInstance: Instance? = nil
 
-			local okService, service = pcall(function() return game:GetService(rootName) end)
+			local okService, service = pcall(function()
+				return game:GetService(rootName)
+			end)
 			if okService and service then
 				rootInstance = service
 			else
@@ -398,8 +468,12 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end
 
 			if rootInstance then
-				local ok, err = pcall(function() wipeChildren(rootInstance) end)
-				if not ok then warn(`[Azul]: Failed to wipe children for root container '{rootName}': {err}`) end
+				local ok, err = pcall(function()
+					wipeChildren(rootInstance)
+				end)
+				if not ok then
+					warn(`[Azul]: Failed to wipe children for root container '{rootName}': {err}`)
+				end
 			else
 				warn(`[Azul]: Destructive build could not find root container '{rootName}', skipping wipe`)
 			end
@@ -423,22 +497,36 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function onInstanceAdded(instance: Instance)
-		if self.suppressOutbound then return end
-		if not shouldIncludeInSnapshot(instance) then return end
+		if self.suppressOutbound then
+			return
+		end
+		if not shouldIncludeInSnapshot(instance) then
+			return
+		end
 
 		local data = AzulService.instanceToData(instance, self.trackedInstances, self.guidMap, self.usedGuids)
-		if not data then return end
+		if not data then
+			return
+		end
 		sendInstanceUpdateDedup(instance)
 		attachListeners(instance)
 	end
 
 	local function onInstanceRemoved(instance)
-		if self.suppressOutbound then return end
-		if not self.trackedInstances[instance] then return end
+		if self.suppressOutbound then
+			return
+		end
+		if not self.trackedInstances[instance] then
+			return
+		end
 
 		local guid = self.trackedInstances[instance]
-		if not guid then guid = instance:GetDebugId(0) end
-		if not guid then return end
+		if not guid then
+			guid = instance:GetDebugId(0)
+		end
+		if not guid then
+			return
+		end
 
 		self.trackedInstances[instance] = nil
 		self.guidMap[guid] = nil
@@ -459,7 +547,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				if AzulService.isScript(descendant) and shouldIncludeInSnapshot(descendant) then
 					local current: Instance? = descendant
 					while current and current ~= game do
-						if shouldIncludeInSnapshot(current) then includeAncestorsOfScripts[current] = true end
+						if shouldIncludeInSnapshot(current) then
+							includeAncestorsOfScripts[current] = true
+						end
 						current = current.Parent
 					end
 				end
@@ -527,7 +617,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				end
 			end
 
-			if index % batchSize == 0 then task.wait() end
+			if index % batchSize == 0 then
+				task.wait()
+			end
 			index += 1
 		end
 
@@ -583,8 +675,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		if not self.handshakeComplete then
 			self.handshakeComplete = true
 			self:debugPrint("Handshake implicitly satisfied by daemon message")
-			if self.ui then self.ui:UpdateHandshakeState(true) end
-			if self._handshakeBindable then pcall(function() self._handshakeBindable:Fire() end) end
+			if self.ui then
+				self.ui:UpdateHandshakeState(true)
+			end
+			if self._handshakeBindable then
+				pcall(function()
+					self._handshakeBindable:Fire()
+				end)
+			end
 		end
 	end
 
@@ -631,7 +729,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			setOutboundSuppressed(true)
 
 			local ok, err = pcall(function()
-				if message.destructive == true then wipeBuildRoots(message.data or {}) end
+				if message.destructive == true then
+					wipeBuildRoots(message.data or {})
+				end
 
 				local created, updated, appliedGuidMap = AzulService.applySnapshotInstances(message.data)
 				for guid, instance in pairs(appliedGuidMap) do
@@ -643,9 +743,13 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end)
 
 			setOutboundSuppressed(false)
-			if not ok then warn("[Azul]: Error applying build snapshot: ", err) end
+			if not ok then
+				warn("[Azul]: Error applying build snapshot: ", err)
+			end
 
-			task.delay(0.5, function() self:stopSync() end)
+			task.delay(0.5, function()
+				self:stopSync()
+			end)
 		elseif message.type == "pushSnapshot" then
 			implicitHandshake()
 			self:infoPrint("Applying push snapshot from daemon")
@@ -666,7 +770,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 					)
 
 					local targetContainer = AzulService.getOrCreatePath(destination)
-					if mapping.destructive then wipeChildren(targetContainer) end
+					if mapping.destructive then
+						wipeChildren(targetContainer)
+					end
 
 					local created, updated, appliedGuidMap =
 						AzulService.applySnapshotInstances(mapping.instances or {}, mapping.destination)
@@ -682,9 +788,13 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end)
 
 			setOutboundSuppressed(false)
-			if not ok then warn("[Azul]: Error applying push snapshot", err) end
+			if not ok then
+				warn("[Azul]: Error applying push snapshot", err)
+			end
 
-			task.delay(0.5, function() self:stopSync() end)
+			task.delay(0.5, function()
+				self:stopSync()
+			end)
 		elseif message.type == "requestPushConfig" then
 			sendDaemonConfig(true)
 		elseif message.type == "handshakeAck" then
@@ -693,8 +803,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				self:debugPrint("Handshake acknowledged by daemon")
 				self:infoPrint("Handshake with Daemon successful")
 				sendDaemonConfig()
-				if self.ui then self.ui:UpdateHandshakeState(true) end
-				if self._handshakeBindable then pcall(function() self._handshakeBindable:Fire() end) end
+				if self.ui then
+					self.ui:UpdateHandshakeState(true)
+				end
+				if self._handshakeBindable then
+					pcall(function()
+						self._handshakeBindable:Fire()
+					end)
+				end
 			end
 		elseif message.type == "daemonDisconnect" then
 			self:infoPrint("Daemon is shutting down; disconnecting plugin")
@@ -730,15 +846,21 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 			local startTime = tick()
 			while tick() - startTime < HANDSHAKE_TIMEOUT do
-				if not self.syncEnabled or not self.wsClient or not self.wsClient.connected then return false end
-				if self.handshakeComplete then return true end
+				if not self.syncEnabled or not self.wsClient or not self.wsClient.connected then
+					return false
+				end
+				if self.handshakeComplete then
+					return true
+				end
 				task.wait(0.1)
 			end
 
 			tries += 1
 
 			--// Otherwise would bloat the console
-			if not self.config.AUTO_CONNECT then warn(`[Azul]: Handshake attempt {tries} failed, retrying...`) end
+			if not self.config.AUTO_CONNECT then
+				warn(`[Azul]: Handshake attempt {tries} failed, retrying...`)
+			end
 
 		--self.wsClient:reconnect()
 		until tries >= HANDSHAKE_MAX_RETRIES
@@ -746,7 +868,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		return self.handshakeComplete
 	end
 
-	function self:reloadSourcemap() sendFullSnapshot() end
+	function self:reloadSourcemap()
+		sendFullSnapshot()
+	end
 
 	function self:startSync(suppressInfo: boolean?)
 		if self.syncEnabled then
@@ -755,13 +879,19 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 		local suppress = suppressInfo == true
 		self._suppressAutoConnectLogs = suppress
-		if not suppress then self:infoPrint("Starting sync...") end
+		if not suppress then
+			self:infoPrint("Starting sync...")
+		end
 		self.syncEnabled = true
 		self.batchingEnabled = false
 		self.batchFlushToken += 1
 
-		if self.ui then self.ui:UpdateSyncState(true) end
-		if self.ui then self.ui:UpdateHandshakeState(false) end
+		if self.ui then
+			self.ui:UpdateSyncState(true)
+		end
+		if self.ui then
+			self.ui:UpdateHandshakeState(false)
+		end
 
 		self.wsClient = WebSocketClient.new(self.config.WS_URL, {
 			debugMode = self.config.DEBUG_MODE,
@@ -787,14 +917,20 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end
 		end)
 
-		self.wsClient:on("message", function(message) processMessage(message) end)
+		self.wsClient:on("message", function(message)
+			processMessage(message)
+		end)
 
 		self.wsClient:on("disconnect", function()
-			self:infoPrint("Disconnected from daemon")
+			if not self._suppressAutoConnectLogs then
+				self:infoPrint("Disconnected from daemon")
+			end
 			self:stopSync()
 		end)
 
-		self.wsClient:on("error", function(error) warn("[Azul]: Connection error:", error) end)
+		self.wsClient:on("error", function(error)
+			warn("[Azul]: Connection error:", error)
+		end)
 
 		local connected = self.wsClient:connect()
 		if not connected then
@@ -824,12 +960,16 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end)
 
 		local descendantAddedConnection = game.DescendantAdded:Connect(function(instance)
-			if self.syncEnabled then onInstanceAdded(instance) end
+			if self.syncEnabled then
+				onInstanceAdded(instance)
+			end
 		end)
 		table.insert(self.connections, descendantAddedConnection)
 
 		local descendantRemovingConnection = game.DescendantRemoving:Connect(function(instance)
-			if self.syncEnabled then onInstanceRemoved(instance) end
+			if self.syncEnabled then
+				onInstanceRemoved(instance)
+			end
 		end)
 		table.insert(self.connections, descendantRemovingConnection)
 
@@ -858,22 +998,37 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end)
 		table.insert(self.connections, heartbeatConnection)
 
-		self:infoPrint("Sync enabled")
+		if not self._suppressAutoConnectLogs then
+			self:infoPrint("Sync enabled")
+		end
 	end
 
 	function self:stopSync(dontRelayDisconnect: boolean?)
-		if not self.syncEnabled then return end
+		if not self.syncEnabled then
+			return
+		end
 
-		if not dontRelayDisconnect then sendMessage("clientDisconnect", {}) end
+		if not dontRelayDisconnect then
+			sendMessage("clientDisconnect", {})
+		end
 
-		self:infoPrint("Stopping sync...")
+		local suppress = self._suppressAutoConnectLogs == true
+		if not suppress then
+			self:infoPrint("Stopping sync...")
+		end
 		self.syncEnabled = false
 		self.handshakeComplete = false
 
-		if self.ui then self.ui:UpdateHandshakeState(false) end
-		if self.ui then self.ui:UpdateSyncState(false) end
+		if self.ui then
+			self.ui:UpdateHandshakeState(false)
+		end
+		if self.ui then
+			self.ui:UpdateSyncState(false)
+		end
 
-		if self.wsClient then self.wsClient:disconnect() end
+		if self.wsClient then
+			self.wsClient:disconnect()
+		end
 		self.wsClient = nil
 
 		self.trackedInstances = {}
@@ -893,12 +1048,18 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 		self.connections = {}
 
+		-- Preserve current suppress state for deciding whether to print "Sync stopped"
+		local wasSuppressed = self._suppressAutoConnectLogs == true
 		self._suppressAutoConnectLogs = false
-		self:infoPrint("Sync stopped")
+		if not wasSuppressed then
+			self:infoPrint("Sync stopped")
+		end
 	end
 
 	function self:onSettingsScopeChanged(newScope: string)
-		if newScope == self.settingsStore:getScope() then return end
+		if newScope == self.settingsStore:getScope() then
+			return
+		end
 
 		self.settingsStore:setScope(newScope)
 		if self.ui then
@@ -913,7 +1074,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 	-- Auto-connect control: run a background task to attempt connects and honor config
 	function self:startAutoConnect()
-		if self._autoConnectThread then return end
+		if self._autoConnectThread then
+			return
+		end
 		self._autoConnectThread = task.spawn(function()
 			local attempts = 0
 			self:infoPrint("Auto-connect enabled")
@@ -930,7 +1093,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				local handshakeFired = false
 				local conn
 				if self._handshakeBindable then
-					conn = self._handshakeBindable.Event:Connect(function() handshakeFired = true end)
+					conn = self._handshakeBindable.Event:Connect(function()
+						handshakeFired = true
+					end)
 				end
 
 				local waitCount = 0
@@ -941,10 +1106,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				do
 					task.wait(1)
 					waitCount += 1
-					if handshakeFired then break end
+					if handshakeFired then
+						break
+					end
 				end
 
-				if conn then conn:Disconnect() end
+				if conn then
+					conn:Disconnect()
+				end
 
 				if self.handshakeComplete then
 					attempts = 0
@@ -965,7 +1134,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 					-- Wait before next attempt
 					task.wait(safeGetNumber(self.config.RECONNECTION_INTERVAL, 5))
 				end
-				if not self.config.AUTO_CONNECT then break end
+				if not self.config.AUTO_CONNECT then
+					break
+				end
 				-- minor yield to avoid tight loop
 				task.wait(0.1)
 			end
@@ -976,10 +1147,16 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	function self:stopAutoConnect()
-		if not self._autoConnectThread then return end
-		local ok, err = pcall(function() task.cancel(self._autoConnectThread) end)
+		if not self._autoConnectThread then
+			return
+		end
+		local ok, err = pcall(function()
+			task.cancel(self._autoConnectThread)
+		end)
 		self._autoConnectThread = nil
-		if not ok then warn("AutoConnect: failed to cancel thread:", err) end
+		if not ok then
+			warn("AutoConnect: failed to cancel thread:", err)
+		end
 	end
 
 	return self :: SyncSession

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -723,11 +723,12 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 
 		local tries = 0
-		local HANDSHAKE_MAX_RETRIES = 5
+		local HANDSHAKE_MAX_RETRIES = self.config.MAX_HANDSHAKES
 		local HANDSHAKE_TIMEOUT = 2
 		self.handshakeComplete = false
+
 		repeat
-			self:debugPrint(`Attempting handshake with daemon... (try {tries} of {HANDSHAKE_MAX_RETRIES})`)
+			self:debugPrint(`Attempting handshake with daemon... (try {tries}/{HANDSHAKE_MAX_RETRIES})`)
 			sendMessage("handshakeStudio", {})
 
 			local startTime = tick()
@@ -738,7 +739,12 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end
 
 			tries += 1
-			warn(`[Azul]: Handshake attempt {tries} failed, retrying...`)
+			
+			--// Otherwise would bloat the console
+			if not self.config.AUTO_CONNECT then
+				warn(`[Azul]: Handshake attempt {tries} failed, retrying...`)
+			end
+
 		--self.wsClient:reconnect()
 		until tries >= HANDSHAKE_MAX_RETRIES
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -12,6 +12,7 @@ SyncSession.__index = SyncSession
 -- Services
 local HttpService = game:GetService("HttpService")
 local RunService = game:GetService("RunService")
+local ScriptEditorService = game:GetService("ScriptEditorService")
 
 -- Modules
 local AzulService = require("./AzulService")
@@ -332,12 +333,13 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 		local path = AzulService.getInstancePath(changedScript)
 		if not path then return end
+		local source = ScriptEditorService:GetEditorSource(changedScript)
 
 		queueScriptChange({
 			guid = guid,
 			path = path,
 			className = changedScript.ClassName,
-			source = changedScript.Source,
+			source = source,
 		})
 	end
 
@@ -354,13 +356,6 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			sendInstanceUpdateDedup(instance)
 		end)
 		table.insert(self.connections, parentConnection)
-
-		if AzulService.isScript(instance) then
-			local sourceConnection = (instance :: Script):GetPropertyChangedSignal("Source"):Connect(function()
-				if self.syncEnabled then onScriptChanged(instance :: Script) end
-			end)
-			table.insert(self.connections, sourceConnection)
-		end
 	end
 
 	local function wipeChildren(container: Instance)
@@ -834,6 +829,18 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			if self.syncEnabled then onInstanceRemoved(instance) end
 		end)
 		table.insert(self.connections, descendantRemovingConnection)
+
+		-- Roblox doesn't have a script specific event for source changes, so we have to use their global signal.
+		local textDocumentChangedConnection = ScriptEditorService.TextDocumentDidChange:Connect(function(scriptDocument, _)
+			if not self.syncEnabled then return end
+
+			local changedScript = scriptDocument:GetScript()
+			if not changedScript then return end
+			if not self.trackedInstances[changedScript] then return end
+
+			onScriptChanged(changedScript :: Script)
+		end)
+		table.insert(self.connections, textDocumentChangedConnection)
 
 		local heartbeatConnection = RunService.Heartbeat:Connect(function(dt)
 			if self.syncEnabled then

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -723,7 +723,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 
 		local tries = 0
-		local HANDSHAKE_MAX_RETRIES = self.config.MAX_HANDSHAKES
+		local HANDSHAKE_MAX_RETRIES = safeGetNumber(self.config.MAX_HANDSHAKES, 5)
 		local HANDSHAKE_TIMEOUT = 2
 		self.handshakeComplete = false
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -356,6 +356,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			sendInstanceUpdateDedup(instance)
 		end)
 		table.insert(self.connections, parentConnection)
+
+		if AzulService.isScript(instance) then
+			local sourceConnection = instance:GetPropertyChangedSignal("Source"):Connect(function()
+				if not self.syncEnabled then return end
+				onScriptChanged(instance :: Script)
+			end)
+			table.insert(self.connections, sourceConnection)
+		end
 	end
 
 	local function wipeChildren(container: Instance)

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/UI.luau
@@ -37,6 +37,7 @@ type AzulUI = {
 	connectButton: PluginToolbarButton,
 	titleImageLabel: ImageLabel,
 	syncButton: any,
+	autoConnectCheckbox: any,
 	debugModeCheckbox: any,
 	silentModeCheckbox: any,
 	settingsScopeDropdown: any,
@@ -236,6 +237,7 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 	mainSection:AddChild(syncButton:GetFrame())
 	self.syncButton = syncButton
 
+
 	-- Silent Mode checkbox
 	local silentModeCheckbox = LabeledCheckbox.new("silentMode", "Silent Mode", Config.SILENT_MODE, false)
 	silentModeCheckbox:SetValue(Config.SILENT_MODE)
@@ -272,6 +274,18 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 	settingsSection:AddChild(settingsScopeDropdown:GetSectionFrame())
 	self.settingsScopeDropdown = settingsScopeDropdown
 
+	-- Auto Connect checkbox
+	local autoConnectCheckbox = LabeledCheckbox.new("autoConnect", "Auto Connect", Config.AUTO_CONNECT, false)
+	autoConnectCheckbox:SetValue(Config.AUTO_CONNECT)
+	autoConnectCheckbox:SetValueChangedFunction(function(newValue)
+		Config.AUTO_CONNECT = newValue
+		self.callbacks.onConfigChanged("AUTO_CONNECT", newValue)
+		debugPrint(`Auto Connect set to: {newValue}`)
+	end)
+	settingsSection:AddChild(autoConnectCheckbox:GetFrame())
+	settingsSection:AddChild(createInfoLabel("Automatically attempt to connect to the daemon when the plugin starts."))
+
+	self.autoConnectCheckbox = autoConnectCheckbox
 	-- WebSocket URL input
 	local websocketUrlLabel = LabeledTextInput.new("websocketUrl", "WebSocket URL:", Config.WS_URL)
 	websocketUrlLabel:SetValue(Config.WS_URL)
@@ -512,6 +526,7 @@ end
 function UI:UpdateConfig()
 	self = self :: AzulUI
 
+	self.autoConnectCheckbox:SetValue(Config.AUTO_CONNECT)
 	self.debugModeCheckbox:SetValue(Config.DEBUG_MODE)
 	self.silentModeCheckbox:SetValue(Config.SILENT_MODE)
 	self.settingsScopeDropdown:SetValue(if self.settingsScope == Enums.scope.GLOBAL then 1 else 2)

--- a/src/build.ts
+++ b/src/build.ts
@@ -4,7 +4,7 @@ import { IPCServer } from "./ipc/server.js";
 import { config } from "./config.js";
 import { log } from "./util/log.js";
 import { SnapshotBuilder } from "./snapshot.js";
-import { RojoSnapshotBuilder } from "./snapshot/rojo.js";
+import { RojoSnapshotBuilder } from "./snapshot/rojo/index.js";
 import type { InstanceData } from "./ipc/messages.js";
 import {
   applySourcemapProperties,

--- a/src/push.ts
+++ b/src/push.ts
@@ -936,7 +936,9 @@ export class PushCommand {
               (e) =>
                 e.isFile() &&
                 isScriptFileName(e.name) &&
-                classifyScriptFileName(e.name).scriptName === baseName,
+                classifyScriptFileName(e.name, {
+                  stripDisambiguationSuffix: true,
+                }).scriptName === baseName,
             );
             if (companionScript) {
               const scriptClass = classifyScriptFileName(companionScript.name, {

--- a/src/push.ts
+++ b/src/push.ts
@@ -5,7 +5,7 @@ import { IPCServer } from "./ipc/server.js";
 import { config } from "./config.js";
 import { log } from "./util/log.js";
 import { SnapshotBuilder } from "./snapshot.js";
-import { RojoSnapshotBuilder } from "./snapshot/rojo.js";
+import { RojoSnapshotBuilder } from "./snapshot/rojo/index.js";
 import { generateGUID } from "./util/id.js";
 import { classifyScriptFileName, isInstanceJsonName, isScriptFileName } from "./util/scriptFile.js";
 import {

--- a/src/push.ts
+++ b/src/push.ts
@@ -7,7 +7,7 @@ import { log } from "./util/log.js";
 import { SnapshotBuilder } from "./snapshot.js";
 import { RojoSnapshotBuilder } from "./snapshot/rojo.js";
 import { generateGUID } from "./util/id.js";
-import { classifyScriptFileName, isScriptFileName } from "./util/scriptFile.js";
+import { classifyScriptFileName, isInstanceJsonName, isScriptFileName } from "./util/scriptFile.js";
 import {
   applySourcemapProperties,
   buildInstancesFromSourcemap,
@@ -852,7 +852,38 @@ export class PushCommand {
         (e) => e.isFile() && initCandidates.includes(e.name),
       );
 
-      if (initEntry) {
+      const initModelEntry = entries.find(
+        (e) => e.isFile() && e.name === "init.model.json",
+      );
+
+      if (initModelEntry) {
+        const full = path.join(dir, "init.model.json");
+        const destPath = [...destSegments, ...relSegments];
+        const key = destPath.join("/");
+        if (!emittedPaths.has(key)) {
+          this.ensureFolder(destPath.slice(0, -1), results, emittedFolders);
+          emittedPaths.add(key);
+          emittedFolders.add(key); // prevent folder emission at this path
+
+          const builder = new RojoSnapshotBuilder({ cwd: process.cwd() });
+          const modelInstances = await builder.parseModelFile(full, destPath);
+          if (modelInstances.length > 0) {
+            const rootInstance = modelInstances[0];
+            if (initEntry) {
+              const scriptClass = classifyScriptFileName(initEntry.name, {
+                stripDisambiguationSuffix: true,
+              }).className;
+              const source = await fsp.readFile(
+                path.join(dir, initEntry.name),
+                "utf-8",
+              );
+              rootInstance.className = scriptClass;
+              rootInstance.source = source;
+            }
+            results.push(...modelInstances);
+          }
+        }
+      } else if (initEntry) {
         const full = path.join(dir, initEntry.name);
         const { className } = classifyScriptFileName(initEntry.name, {
           stripDisambiguationSuffix: true,
@@ -884,7 +915,58 @@ export class PushCommand {
           continue; // already emitted as the container
         }
 
+        if (initModelEntry && entry.name === "init.model.json") {
+          continue;
+        }
+
+        if (isInstanceJsonName(entry.name)) {
+          const baseName = entry.name.slice(0, -".model.json".length);
+          const destPath = [...destSegments, ...relSegments, baseName];
+          const key = destPath.join("/");
+          if (emittedPaths.has(key)) continue;
+
+          this.ensureFolder(destPath.slice(0, -1), results, emittedFolders);
+          emittedPaths.add(key);
+
+          const builder = new RojoSnapshotBuilder({ cwd: process.cwd() });
+          const modelInstances = await builder.parseModelFile(full, destPath);
+          if (modelInstances.length > 0) {
+            const rootInstance = modelInstances[0];
+            const companionScript = entries.find(
+              (e) =>
+                e.isFile() &&
+                isScriptFileName(e.name) &&
+                classifyScriptFileName(e.name).scriptName === baseName,
+            );
+            if (companionScript) {
+              const scriptClass = classifyScriptFileName(companionScript.name, {
+                stripDisambiguationSuffix: true,
+              }).className;
+              const source = await fsp.readFile(
+                path.join(dir, companionScript.name),
+                "utf-8",
+              );
+              rootInstance.className = scriptClass;
+              rootInstance.source = source;
+            }
+            results.push(...modelInstances);
+          }
+          continue;
+        }
+
         if (!isScriptFileName(entry.name)) continue;
+
+        // Skip scripts that are companion scripts of a companion model file
+        const baseName = classifyScriptFileName(entry.name, {
+          stripDisambiguationSuffix: true,
+        }).scriptName;
+        const companionModelName = `${baseName}.model.json`;
+        const hasCompanionModel = entries.some(
+          (e) => e.isFile() && e.name === companionModelName,
+        );
+        if (hasCompanionModel) {
+          continue;
+        }
 
         const { className, scriptName } = classifyScriptFileName(entry.name, {
           stripDisambiguationSuffix: true,

--- a/src/snapshot/rojo.ts
+++ b/src/snapshot/rojo.ts
@@ -39,11 +39,12 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
       return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
     }
   }
+  /*
   if (normalizedType === "color3uint8") {
     if (Array.isArray(value) && value.length === 3) {
       return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
     }
-  }
+  } */
   if (normalizedType === "cframe") {
     if (Array.isArray(value)) {
       return { __type: "CFrame", components: value };

--- a/src/snapshot/rojo.ts
+++ b/src/snapshot/rojo.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { log } from "../util/log.js";
 import {
   classifyScriptFileName,
+  isInstanceJsonName,
   isScriptFileName,
   ScriptClassName,
 } from "../util/scriptFile.js";
@@ -19,6 +20,134 @@ export interface RojoSnapshotOptions {
   projectFile?: string;
   cwd?: string;
   destPrefix?: string[];
+}
+
+function convertExplicitRojoProperty(typeStr: string, value: any): any {
+  const normalizedType = typeStr.toLowerCase();
+  if (normalizedType === "vector3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Vector3", x: value[0], y: value[1], z: value[2] };
+    }
+  }
+  if (normalizedType === "vector2") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "Vector2", x: value[0], y: value[1] };
+    }
+  }
+  if (normalizedType === "color3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "color3uint8") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "cframe") {
+    if (Array.isArray(value)) {
+      return { __type: "CFrame", components: value };
+    }
+  }
+  if (normalizedType === "udim") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "UDim", scale: value[0], offset: value[1] };
+    }
+  }
+  if (normalizedType === "udim2") {
+    if (Array.isArray(value) && value.length === 4) {
+      return { __type: "UDim2", xScale: value[0], xOffset: value[1], yScale: value[2], yOffset: value[3] };
+    }
+  }
+  if (normalizedType === "brickcolor") {
+    return { __type: "BrickColor", number: typeof value === "number" ? value : 0 };
+  }
+  if (normalizedType === "numberrange") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "NumberRange", min: value[0], max: value[1] };
+    }
+  }
+  if (normalizedType === "rect") {
+    if (Array.isArray(value)) {
+      if (value.length === 4) {
+        return { __type: "Rect", minX: value[0], minY: value[1], maxX: value[2], maxY: value[3] };
+      }
+      if (value.length === 2 && Array.isArray(value[0]) && Array.isArray(value[1])) {
+        return { __type: "Rect", minX: value[0][0], minY: value[0][1], maxX: value[1][0], maxY: value[1][1] };
+      }
+    }
+  }
+  if (normalizedType === "enum") {
+    if (typeof value === "object" && value !== null) {
+      const enumType = value.enumType || value.EnumType || value.Type || value.type;
+      const enumValue = value.value || value.Value || value.name || value.Name;
+      if (enumType && enumValue !== undefined) {
+        return {
+          __type: "Enum",
+          enumType: String(enumType).replace(/^Enum\./, ""),
+          value: enumValue
+        };
+      }
+    }
+    return value;
+  }
+  return value;
+}
+
+export function convertImplicitRojoProperty(propName: string, val: any): any {
+  if (val === null || val === undefined) {
+    return null;
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "Type" in val && "Value" in val) {
+    return convertExplicitRojoProperty(val.Type, val.Value);
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "type" in val && "value" in val) {
+    return convertExplicitRojoProperty(val.type, val.value);
+  }
+
+  if (Array.isArray(val)) {
+    const allNumbers = val.every(v => typeof v === 'number');
+    if (allNumbers) {
+      const lowerName = propName.toLowerCase();
+      if (val.length === 12) {
+        return { __type: "CFrame", components: val };
+      }
+      if (val.length === 3) {
+        if (lowerName.includes("color")) {
+          if (val.some(v => v > 1.0)) {
+            return { __type: "Color3uint8", r: val[0], g: val[1], b: val[2] };
+          }
+          return { __type: "Color3", r: val[0], g: val[1], b: val[2] };
+        }
+        return { __type: "Vector3", x: val[0], y: val[1], z: val[2] };
+      }
+      if (val.length === 2) {
+        if (lowerName.includes("range")) {
+          return { __type: "NumberRange", min: val[0], max: val[1] };
+        }
+        if (lowerName.includes("udim") || lowerName.includes("size") || lowerName.includes("position")) {
+          return { __type: "UDim", scale: val[0], offset: val[1] };
+        }
+        return { __type: "Vector2", x: val[0], y: val[1] };
+      }
+      if (val.length === 4) {
+        if (lowerName.includes("rect")) {
+          return { __type: "Rect", minX: val[0], minY: val[1], maxX: val[2], maxY: val[3] };
+        }
+        return { __type: "UDim2", xScale: val[0], xOffset: val[1], yScale: val[2], yOffset: val[3] };
+      }
+    }
+  }
+
+  if (typeof val === "object" && val !== null) {
+    const copy: Record<string, any> = {};
+    for (const [k, v] of Object.entries(val)) {
+      copy[k] = convertImplicitRojoProperty(k, v);
+    }
+    return copy;
+  }
+
+  return val;
 }
 
 /**
@@ -230,6 +359,155 @@ export class RojoSnapshotBuilder {
     }
   }
 
+  public async parseModelFile(
+    filePath: string,
+    destPath: string[],
+  ): Promise<InstanceData[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch (error) {
+      throw new Error(`Failed to read .model.json at ${filePath}: ${error}`);
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(`Failed to parse .model.json at ${filePath}: ${error}`);
+    }
+
+    const results: InstanceData[] = [];
+    const name = destPath[destPath.length - 1] || "Model";
+    await this.parseModelNode(parsed, name, destPath, path.dirname(filePath), results);
+    return results;
+  }
+
+  private async parseModelNode(
+    node: any,
+    name: string,
+    currentPath: string[],
+    baseDir: string,
+    results: InstanceData[],
+  ): Promise<void> {
+    if (typeof node !== "object" || node === null) return;
+
+    // Check for $path
+    const pathHint = node.$path || node.path;
+    if (typeof pathHint === "string") {
+      const absPath = path.resolve(baseDir, pathHint);
+      const exists = await this.exists(absPath);
+      if (!exists) {
+        throw new Error(`$path target ${absPath} does not exist.`);
+      }
+
+      const kind = await this.pathKind(absPath);
+      if (kind === "file") {
+        const fileName = path.basename(absPath);
+        if (isInstanceJsonName(fileName)) {
+          const modelInstances = await this.parseModelFile(absPath, currentPath);
+          results.push(...modelInstances);
+          return;
+        } else if (this.isJsonModuleFile(fileName)) {
+          const source = await this.readJsonModuleSource(absPath);
+          this.moduleContainers.add(currentPath.join("/"));
+          results.push({
+            guid: this.makeGuid(),
+            className: "ModuleScript",
+            name,
+            path: [...currentPath],
+            source,
+          });
+          return;
+        } else if (isScriptFileName(fileName)) {
+          const { className } = classifyScriptFileName(fileName);
+          const source = await fs.readFile(absPath, "utf-8");
+          this.moduleContainers.add(currentPath.join("/"));
+          results.push({
+            guid: this.makeGuid(),
+            className,
+            name,
+            path: [...currentPath],
+            source,
+          });
+          return;
+        } else {
+          throw new Error(`Unsupported $path file type: ${absPath}`);
+        }
+      } else if (kind === "dir") {
+        await this.walkDirectory(absPath, currentPath, results, new Set());
+        return;
+      }
+    }
+
+    const className = node.ClassName || node.className || node.$className || "Folder";
+    
+    // Resolve properties
+    const rawProperties = node.Properties || node.properties || node.$properties;
+    const properties: Record<string, any> = {};
+    if (rawProperties && typeof rawProperties === "object") {
+      for (const [k, v] of Object.entries(rawProperties)) {
+        properties[k] = convertImplicitRojoProperty(k, v);
+      }
+    }
+
+    // Resolve attributes
+    const rawAttributes = node.Attributes || node.attributes || node.$attributes;
+    const attributes: Record<string, any> = {};
+    if (rawAttributes && typeof rawAttributes === "object") {
+      for (const [k, v] of Object.entries(rawAttributes)) {
+        attributes[k] = v;
+      }
+    }
+
+    // Resolve tags
+    const rawTags = node.Tags || node.tags || node.$tags;
+    let tags: string[] | undefined = undefined;
+    if (Array.isArray(rawTags)) {
+      tags = rawTags.map(t => String(t));
+    }
+
+    const instance: InstanceData = {
+      guid: this.makeGuid(),
+      className,
+      name,
+      path: [...currentPath],
+    };
+
+    if (Object.keys(properties).length > 0) {
+      instance.properties = properties;
+    }
+    if (Object.keys(attributes).length > 0) {
+      instance.attributes = attributes;
+    }
+    if (tags && tags.length > 0) {
+      instance.tags = tags;
+    }
+
+    this.moduleContainers.add(currentPath.join("/"));
+    results.push(instance);
+
+    // Recursively parse children
+    const rawChildren = node.Children || node.children || node.$children;
+    if (Array.isArray(rawChildren)) {
+      for (let i = 0; i < rawChildren.length; i++) {
+        const childNode = rawChildren[i];
+        if (typeof childNode === "object" && childNode !== null) {
+          const childName = childNode.Name || childNode.name || childNode.$name || `Instance${i}`;
+          const childPath = [...currentPath, childName];
+          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+        }
+      }
+    } else if (rawChildren && typeof rawChildren === "object") {
+      for (const [childName, childNode] of Object.entries(rawChildren)) {
+        if (typeof childNode === "object" && childNode !== null) {
+          const childPath = [...currentPath, childName];
+          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+        }
+      }
+    }
+  }
+
   private async emitNode(
     name: string,
     node: Record<string, any>,
@@ -250,11 +528,69 @@ export class RojoSnapshotBuilder {
       source: string;
       className?: ScriptClassName;
     } | null = null;
+    let initModelFile: string | null = null;
+
     if (absPath && pathKind === "dir") {
+      const modelPath = path.join(absPath, "init.model.json");
+      if (await this.exists(modelPath)) {
+        initModelFile = modelPath;
+      }
       initScript = await this.findInit(absPath);
     } else if (absPath && pathKind === "file") {
       const fileName = path.basename(absPath);
-      if (this.isJsonModuleFile(fileName)) {
+      if (isInstanceJsonName(fileName)) {
+        this.ensureFolder(pathSegments.slice(0, -1), results);
+        const modelInstances = await this.parseModelFile(absPath, pathSegments);
+        if (modelInstances.length > 0) {
+          const rootInstance = modelInstances[0];
+          
+          if (node.$className) {
+            rootInstance.className = node.$className;
+          }
+          
+          if (node.$properties) {
+            const mergedProps = { ...(rootInstance.properties || {}) };
+            for (const [k, v] of Object.entries(node.$properties)) {
+              mergedProps[k] = convertImplicitRojoProperty(k, v);
+            }
+            rootInstance.properties = mergedProps;
+          }
+
+          if (node.$attributes) {
+            const mergedAttrs = { ...(rootInstance.attributes || {}) };
+            for (const [k, v] of Object.entries(node.$attributes)) {
+              mergedAttrs[k] = v;
+            }
+            rootInstance.attributes = mergedAttrs;
+          }
+
+          if (node.$tags) {
+            const existingTags = new Set(rootInstance.tags || []);
+            if (Array.isArray(node.$tags)) {
+              for (const tag of node.$tags) {
+                existingTags.add(String(tag));
+              }
+            }
+            rootInstance.tags = [...existingTags];
+          }
+
+          results.push(...modelInstances);
+        }
+
+        // Recurse into children defined in JSON
+        for (const [childName, childValue] of Object.entries(node)) {
+          if (childName.startsWith("$")) continue;
+          if (typeof childValue !== "object" || childValue === null) continue;
+          await this.emitNode(
+            childName,
+            childValue,
+            [...pathSegments, childName],
+            projectDir,
+            results,
+          );
+        }
+        return;
+      } else if (this.isJsonModuleFile(fileName)) {
         const source = await this.readJsonModuleSource(absPath);
         initScript = { fileName, source, className: "ModuleScript" };
       } else {
@@ -266,8 +602,55 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    // If there's an init script, the folder becomes a ModuleScript at the same path.
-    if (initScript) {
+    if (initModelFile) {
+      this.ensureFolder(pathSegments.slice(0, -1), results);
+      this.moduleContainers.add(pathSegments.join("/"));
+      
+      const modelInstances = await this.parseModelFile(initModelFile, pathSegments);
+      if (modelInstances.length > 0) {
+        const rootInstance = modelInstances[0];
+        
+        if (node.$className) {
+          rootInstance.className = node.$className;
+        }
+        
+        if (node.$properties) {
+          const mergedProps = { ...(rootInstance.properties || {}) };
+          for (const [k, v] of Object.entries(node.$properties)) {
+            mergedProps[k] = convertImplicitRojoProperty(k, v);
+          }
+          rootInstance.properties = mergedProps;
+        }
+
+        if (node.$attributes) {
+          const mergedAttrs = { ...(rootInstance.attributes || {}) };
+          for (const [k, v] of Object.entries(node.$attributes)) {
+            mergedAttrs[k] = v;
+          }
+          rootInstance.attributes = mergedAttrs;
+        }
+
+        if (node.$tags) {
+          const existingTags = new Set(rootInstance.tags || []);
+          if (Array.isArray(node.$tags)) {
+            for (const tag of node.$tags) {
+              existingTags.add(String(tag));
+            }
+          }
+          rootInstance.tags = [...existingTags];
+        }
+
+        if (initScript) {
+          const scriptClass =
+            initScript.className ??
+            classifyScriptFileName(initScript.fileName).className;
+          rootInstance.className = scriptClass;
+          rootInstance.source = initScript.source;
+        }
+
+        results.push(...modelInstances);
+      }
+    } else if (initScript) {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       this.moduleContainers.add(pathSegments.join("/"));
       const scriptClass =
@@ -339,8 +722,40 @@ export class RojoSnapshotBuilder {
       (e) => e.isFile() && initCandidates.includes(e.name),
     );
 
-    if (initEntry) {
-      const key = destPath.join("/");
+    const initModelEntry = entries.find(
+      (e) => e.isFile() && e.name === "init.model.json"
+    );
+
+    const handledEntries = new Set<string>();
+    const key = destPath.join("/");
+
+    if (initModelEntry) {
+      handledEntries.add("init.model.json");
+      if (!this.moduleContainers.has(key)) {
+        this.moduleContainers.add(key);
+        this.ensureFolder(destPath.slice(0, -1), results);
+        
+        const modelInstances = await this.parseModelFile(
+          path.join(dirPath, "init.model.json"),
+          destPath,
+        );
+        if (modelInstances.length > 0) {
+          const rootInstance = modelInstances[0];
+          if (initEntry) {
+            handledEntries.add(initEntry.name);
+            const scriptClass = classifyScriptFileName(initEntry.name).className;
+            const source = await fs.readFile(
+              path.join(dirPath, initEntry.name),
+              "utf-8",
+            );
+            rootInstance.className = scriptClass;
+            rootInstance.source = source;
+          }
+          results.push(...modelInstances);
+        }
+      }
+    } else if (initEntry) {
+      handledEntries.add(initEntry.name);
       if (!this.moduleContainers.has(key)) {
         this.moduleContainers.add(key);
         this.ensureFolder(destPath.slice(0, -1), results);
@@ -378,11 +793,44 @@ export class RojoSnapshotBuilder {
     }
 
     for (const entry of entries) {
+      if (handledEntries.has(entry.name)) continue;
       const fullPath = path.join(dirPath, entry.name);
       if (this.isIgnored(fullPath)) continue;
 
       // Skip entries explicitly defined in the project tree
       if (definedChildren.has(entry.name)) {
+        continue;
+      }
+
+      if (entry.isFile() && entry.name.endsWith(".model.json") && entry.name !== "init.model.json") {
+        handledEntries.add(entry.name);
+        const baseName = entry.name.slice(0, -".model.json".length);
+        if (definedChildren.has(baseName)) {
+          continue;
+        }
+
+        this.ensureFolder(destPath, results);
+        const modelInstances = await this.parseModelFile(fullPath, [...destPath, baseName]);
+        if (modelInstances.length > 0) {
+          const rootInstance = modelInstances[0];
+          const companionScript = entries.find(
+            (e) =>
+              e.isFile() &&
+              isScriptFileName(e.name) &&
+              classifyScriptFileName(e.name).scriptName === baseName,
+          );
+          if (companionScript) {
+            handledEntries.add(companionScript.name);
+            const scriptClass = classifyScriptFileName(companionScript.name).className;
+            const source = await fs.readFile(
+              path.join(dirPath, companionScript.name),
+              "utf-8",
+            );
+            rootInstance.className = scriptClass;
+            rootInstance.source = source;
+          }
+          results.push(...modelInstances);
+        }
         continue;
       }
 

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -455,7 +455,7 @@ export class RojoSnapshotBuilder {
           if (node.$attributes) {
             const mergedAttrs = { ...(rootInstance.attributes || {}) };
             for (const [k, v] of Object.entries(node.$attributes)) {
-              mergedAttrs[k] = v;
+              mergedAttrs[k] = convertImplicitRojoProperty(k, v);
             }
             rootInstance.attributes = mergedAttrs;
           }
@@ -524,7 +524,7 @@ export class RojoSnapshotBuilder {
         if (node.$attributes) {
           const mergedAttrs = { ...(rootInstance.attributes || {}) };
           for (const [k, v] of Object.entries(node.$attributes)) {
-            mergedAttrs[k] = v;
+            mergedAttrs[k] = convertImplicitRojoProperty(k, v);
           }
           rootInstance.attributes = mergedAttrs;
         }

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -23,6 +23,9 @@ export interface RojoSnapshotOptions {
   destPrefix?: string[];
 }
 
+/**
+ * Builds InstanceData[] from a Rojo-style default.project.json (compat layer).
+ */
 export class RojoSnapshotBuilder {
   private projectFile: string;
   private cwd: string;
@@ -54,10 +57,16 @@ export class RojoSnapshotBuilder {
 
     log.debug(`destPrefix: ${this.destPrefix.join("/")}`);
 
+    // If the root of the project tree doesn't have a $className of "Datamodel", the Rojo project is not a Place and
+    // we cannot guess the root of the emitted tree.
     if (
       (!tree.$className || tree.$className !== "Datamodel") &&
       (!this.destPrefix || this.destPrefix.length === 0)
     ) {
+      /**
+       * Rojo error:
+       * Cannot sync a model as a place. Ensure Rojo is serving a project file that has a DataModel at the root of its tree and try again.
+       */
       log.error(
         `Cannot build Rojo compatibility snapshot: project file does not have a Datamodel root.`,
       );
@@ -97,6 +106,7 @@ export class RojoSnapshotBuilder {
         );
         const source = await fs.readFile(absRoot, "utf-8");
 
+        // If the root is a file, it becomes the single instance emitted at the destPrefix (or root if no prefix).
         const destPath =
           this.destPrefix.length === 0
             ? [scriptName]
@@ -123,10 +133,12 @@ export class RojoSnapshotBuilder {
       }
     }
 
+    // Walk any children defined in the root of the project tree (if $path is not a file)
     if (hasChildren) {
       await this.walkTree(tree, [], projectDir, results);
     }
 
+    // Stable ordering: shallow-first, then lexical for determinism
     results.sort((a, b) => {
       if (a.path.length !== b.path.length) {
         return a.path.length - b.path.length;
@@ -240,7 +252,13 @@ export class RojoSnapshotBuilder {
 
     const results: InstanceData[] = [];
     const name = destPath[destPath.length - 1] || "Model";
-    await this.parseModelNode(parsed, name, destPath, path.dirname(filePath), results);
+    await this.parseModelNode(
+      parsed,
+      name,
+      destPath,
+      path.dirname(filePath),
+      results,
+    );
     return results;
   }
 
@@ -265,7 +283,10 @@ export class RojoSnapshotBuilder {
       if (kind === "file") {
         const fileName = path.basename(absPath);
         if (isInstanceJsonName(fileName)) {
-          const modelInstances = await this.parseModelFile(absPath, currentPath);
+          const modelInstances = await this.parseModelFile(
+            absPath,
+            currentPath,
+          );
           results.push(...modelInstances);
           return;
         } else if (this.isJsonModuleFile(fileName)) {
@@ -300,9 +321,11 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    const className = node.ClassName || node.className || node.$className || "Folder";
+    const className =
+      node.ClassName || node.className || node.$className || "Folder";
 
-    const rawProperties = node.Properties || node.properties || node.$properties;
+    const rawProperties =
+      node.Properties || node.properties || node.$properties;
     const properties: Record<string, any> = {};
     if (rawProperties && typeof rawProperties === "object") {
       for (const [k, v] of Object.entries(rawProperties)) {
@@ -310,7 +333,8 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    const rawAttributes = node.Attributes || node.attributes || node.$attributes;
+    const rawAttributes =
+      node.Attributes || node.attributes || node.$attributes;
     const attributes: Record<string, any> = {};
     if (rawAttributes && typeof rawAttributes === "object") {
       for (const [k, v] of Object.entries(rawAttributes)) {
@@ -321,7 +345,7 @@ export class RojoSnapshotBuilder {
     const rawTags = node.Tags || node.tags || node.$tags;
     let tags: string[] | undefined = undefined;
     if (Array.isArray(rawTags)) {
-      tags = rawTags.map(t => String(t));
+      tags = rawTags.map((t) => String(t));
     }
 
     const instance: InstanceData = {
@@ -349,16 +373,32 @@ export class RojoSnapshotBuilder {
       for (let i = 0; i < rawChildren.length; i++) {
         const childNode = rawChildren[i];
         if (typeof childNode === "object" && childNode !== null) {
-          const childName = childNode.Name || childNode.name || childNode.$name || `Instance${i}`;
+          const childName =
+            childNode.Name ||
+            childNode.name ||
+            childNode.$name ||
+            `Instance${i}`;
           const childPath = [...currentPath, childName];
-          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+          await this.parseModelNode(
+            childNode,
+            childName,
+            childPath,
+            baseDir,
+            results,
+          );
         }
       }
     } else if (rawChildren && typeof rawChildren === "object") {
       for (const [childName, childNode] of Object.entries(rawChildren)) {
         if (typeof childNode === "object" && childNode !== null) {
           const childPath = [...currentPath, childName];
-          await this.parseModelNode(childNode, childName, childPath, baseDir, results);
+          await this.parseModelNode(
+            childNode,
+            childName,
+            childPath,
+            baseDir,
+            results,
+          );
         }
       }
     }
@@ -399,11 +439,11 @@ export class RojoSnapshotBuilder {
         const modelInstances = await this.parseModelFile(absPath, pathSegments);
         if (modelInstances.length > 0) {
           const rootInstance = modelInstances[0];
-          
+
           if (node.$className) {
             rootInstance.className = node.$className;
           }
-          
+
           if (node.$properties) {
             const mergedProps = { ...(rootInstance.properties || {}) };
             for (const [k, v] of Object.entries(node.$properties)) {
@@ -457,18 +497,22 @@ export class RojoSnapshotBuilder {
       }
     }
 
+    // If there's an init script or an init model file, the folder becomes that instance.
     if (initModelFile) {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       this.moduleContainers.add(pathSegments.join("/"));
-      
-      const modelInstances = await this.parseModelFile(initModelFile, pathSegments);
+
+      const modelInstances = await this.parseModelFile(
+        initModelFile,
+        pathSegments,
+      );
       if (modelInstances.length > 0) {
         const rootInstance = modelInstances[0];
-        
+
         if (node.$className) {
           rootInstance.className = node.$className;
         }
-        
+
         if (node.$properties) {
           const mergedProps = { ...(rootInstance.properties || {}) };
           for (const [k, v] of Object.entries(node.$properties)) {
@@ -505,7 +549,10 @@ export class RojoSnapshotBuilder {
 
         results.push(...modelInstances);
       }
-    } else if (initScript) {
+    }
+
+    // If there's an init script, the folder becomes a ModuleScript at the same path.
+    else if (initScript) {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       this.moduleContainers.add(pathSegments.join("/"));
       const scriptClass =
@@ -518,7 +565,9 @@ export class RojoSnapshotBuilder {
         path: [...pathSegments],
         source: initScript.source,
       });
-    } else {
+    }
+    // If no special file (model or script) was found, emit a standard instance.
+    else {
       this.ensureFolder(pathSegments.slice(0, -1), results);
       results.push({
         guid: this.makeGuid(),
@@ -528,6 +577,7 @@ export class RojoSnapshotBuilder {
       });
     }
 
+    // Recurse into children defined in JSON
     for (const [childName, childValue] of Object.entries(node)) {
       if (childName.startsWith("$")) continue;
       if (typeof childValue !== "object" || childValue === null) continue;
@@ -540,6 +590,7 @@ export class RojoSnapshotBuilder {
       );
     }
 
+    // Walk filesystem for $path mappings
     if (absPath && pathKind === "dir") {
       await this.walkDirectory(absPath, pathSegments, results, definedChildren);
     }
@@ -553,6 +604,7 @@ export class RojoSnapshotBuilder {
       return node.$className;
     }
     if (pathSegments.length === 1) {
+      // Service root
       return pathSegments[0];
     }
     return "Folder";
@@ -569,12 +621,13 @@ export class RojoSnapshotBuilder {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
     const initCandidates = this.getInitCandidates();
 
+    // If this directory has an init, the directory becomes that script; children attach under it
     const initEntry = entries.find(
       (e) => e.isFile() && initCandidates.includes(e.name),
     );
 
     const initModelEntry = entries.find(
-      (e) => e.isFile() && e.name === "init.model.json"
+      (e) => e.isFile() && e.name === "init.model.json",
     );
 
     const handledEntries = new Set<string>();
@@ -585,7 +638,7 @@ export class RojoSnapshotBuilder {
       if (!this.moduleContainers.has(key)) {
         this.moduleContainers.add(key);
         this.ensureFolder(destPath.slice(0, -1), results);
-        
+
         const modelInstances = await this.parseModelFile(
           path.join(dirPath, "init.model.json"),
           destPath,
@@ -594,7 +647,9 @@ export class RojoSnapshotBuilder {
           const rootInstance = modelInstances[0];
           if (initEntry) {
             handledEntries.add(initEntry.name);
-            const scriptClass = classifyScriptFileName(initEntry.name).className;
+            const scriptClass = classifyScriptFileName(
+              initEntry.name,
+            ).className;
             const source = await fs.readFile(
               path.join(dirPath, initEntry.name),
               "utf-8",
@@ -627,6 +682,7 @@ export class RojoSnapshotBuilder {
       this.ensureFolder(destPath, results);
     }
 
+    // Sub-project overrides
     const subProjectPath = path.join(dirPath, "default.project.json");
     if (await this.exists(subProjectPath)) {
       const previousProjectFile = this.projectFile;
@@ -647,11 +703,16 @@ export class RojoSnapshotBuilder {
       const fullPath = path.join(dirPath, entry.name);
       if (this.isIgnored(fullPath)) continue;
 
+      // Skip entries explicitly defined in the project tree
       if (definedChildren.has(entry.name)) {
         continue;
       }
 
-      if (entry.isFile() && entry.name.endsWith(".model.json") && entry.name !== "init.model.json") {
+      if (
+        entry.isFile() &&
+        entry.name.endsWith(".model.json") &&
+        entry.name !== "init.model.json"
+      ) {
         handledEntries.add(entry.name);
         const baseName = entry.name.slice(0, -".model.json".length);
         if (definedChildren.has(baseName)) {
@@ -659,7 +720,10 @@ export class RojoSnapshotBuilder {
         }
 
         this.ensureFolder(destPath, results);
-        const modelInstances = await this.parseModelFile(fullPath, [...destPath, baseName]);
+        const modelInstances = await this.parseModelFile(fullPath, [
+          ...destPath,
+          baseName,
+        ]);
         if (modelInstances.length > 0) {
           const rootInstance = modelInstances[0];
           const companionScript = entries.find(
@@ -670,7 +734,9 @@ export class RojoSnapshotBuilder {
           );
           if (companionScript) {
             handledEntries.add(companionScript.name);
-            const scriptClass = classifyScriptFileName(companionScript.name).className;
+            const scriptClass = classifyScriptFileName(
+              companionScript.name,
+            ).className;
             const source = await fs.readFile(
               path.join(dirPath, companionScript.name),
               "utf-8",
@@ -693,6 +759,7 @@ export class RojoSnapshotBuilder {
         continue;
       }
 
+      // Skip init files here (handled earlier)
       if (initCandidates.includes(entry.name)) {
         continue;
       }
@@ -736,6 +803,9 @@ export class RojoSnapshotBuilder {
     }
   }
 
+  /**
+   * Ensure a Folder chain exists for the given path.
+   */
   private ensureFolder(pathSegments: string[], results: InstanceData[]): void {
     if (pathSegments.length === 0) return;
     const key = pathSegments.join("/");
@@ -751,6 +821,11 @@ export class RojoSnapshotBuilder {
     });
   }
 
+  /**
+   * Finds an init script (init.lua, init.server.luau, etc.) in a directory.
+   * @param dirPath
+   * @returns The file name and source of the init script, or null if not found.
+   */
   private async findInit(
     dirPath: string,
   ): Promise<{ fileName: string; source: string } | null> {
@@ -767,6 +842,9 @@ export class RojoSnapshotBuilder {
     return null;
   }
 
+  /**
+   * Returns a list of potential init script filenames.
+   */
   private getInitCandidates(): string[] {
     const bases = ["init", "init.server", "init.client", "init.module"];
 

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -75,7 +75,7 @@ export class RojoSnapshotBuilder {
         `- Run "azul push" to specify a destination path that is not the root (e.g. "azul push -s . -d Workspace.${project.name || "RojoProject"} --rojo")`,
       );
       log.error(
-        `- Make sure the project file has a Datamodel root (e.g. "tree": { "$className": "Datamodel", ... })`,
+        `- Make sure the project file has a DataModel root (e.g. "tree": { "$className": "DataModel", ... })`,
       );
       throw new Error(`Cannot build from Rojo project.`);
     }

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -57,10 +57,10 @@ export class RojoSnapshotBuilder {
 
     log.debug(`destPrefix: ${this.destPrefix.join("/")}`);
 
-    // If the root of the project tree doesn't have a $className of "Datamodel", the Rojo project is not a Place and
+    // If the root of the project tree doesn't have a $className of "DataModel", the Rojo project is not a Place and
     // we cannot guess the root of the emitted tree.
     if (
-      (!tree.$className || tree.$className !== "Datamodel") &&
+      (!tree.$className || tree.$className !== "DataModel") &&
       (!this.destPrefix || this.destPrefix.length === 0)
     ) {
       /**
@@ -68,7 +68,7 @@ export class RojoSnapshotBuilder {
        * Cannot sync a model as a place. Ensure Rojo is serving a project file that has a DataModel at the root of its tree and try again.
        */
       log.error(
-        `Cannot build Rojo compatibility snapshot: project file does not have a Datamodel root.`,
+        `Cannot build Rojo compatibility snapshot: project file does not have a DataModel root.`,
       );
       log.error(`To fix this, either:`);
       log.error(

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -1,14 +1,15 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { log } from "../util/log.js";
+import { log } from "../../util/log.js";
 import {
   classifyScriptFileName,
   isInstanceJsonName,
   isScriptFileName,
   ScriptClassName,
-} from "../util/scriptFile.js";
-import type { InstanceData } from "../ipc/messages.js";
+} from "../../util/scriptFile.js";
+import type { InstanceData } from "../../ipc/messages.js";
+import { convertImplicitRojoProperty } from "./convert.js";
 
 interface RojoProject {
   name: string;
@@ -22,138 +23,6 @@ export interface RojoSnapshotOptions {
   destPrefix?: string[];
 }
 
-function convertExplicitRojoProperty(typeStr: string, value: any): any {
-  const normalizedType = typeStr.toLowerCase();
-  if (normalizedType === "vector3") {
-    if (Array.isArray(value) && value.length === 3) {
-      return { __type: "Vector3", x: value[0], y: value[1], z: value[2] };
-    }
-  }
-  if (normalizedType === "vector2") {
-    if (Array.isArray(value) && value.length === 2) {
-      return { __type: "Vector2", x: value[0], y: value[1] };
-    }
-  }
-  if (normalizedType === "color3") {
-    if (Array.isArray(value) && value.length === 3) {
-      return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
-    }
-  }
-  /*
-  if (normalizedType === "color3uint8") {
-    if (Array.isArray(value) && value.length === 3) {
-      return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
-    }
-  } */
-  if (normalizedType === "cframe") {
-    if (Array.isArray(value)) {
-      return { __type: "CFrame", components: value };
-    }
-  }
-  if (normalizedType === "udim") {
-    if (Array.isArray(value) && value.length === 2) {
-      return { __type: "UDim", scale: value[0], offset: value[1] };
-    }
-  }
-  if (normalizedType === "udim2") {
-    if (Array.isArray(value) && value.length === 4) {
-      return { __type: "UDim2", xScale: value[0], xOffset: value[1], yScale: value[2], yOffset: value[3] };
-    }
-  }
-  if (normalizedType === "brickcolor") {
-    return { __type: "BrickColor", number: typeof value === "number" ? value : 0 };
-  }
-  if (normalizedType === "numberrange") {
-    if (Array.isArray(value) && value.length === 2) {
-      return { __type: "NumberRange", min: value[0], max: value[1] };
-    }
-  }
-  if (normalizedType === "rect") {
-    if (Array.isArray(value)) {
-      if (value.length === 4) {
-        return { __type: "Rect", minX: value[0], minY: value[1], maxX: value[2], maxY: value[3] };
-      }
-      if (value.length === 2 && Array.isArray(value[0]) && Array.isArray(value[1])) {
-        return { __type: "Rect", minX: value[0][0], minY: value[0][1], maxX: value[1][0], maxY: value[1][1] };
-      }
-    }
-  }
-  if (normalizedType === "enum") {
-    if (typeof value === "object" && value !== null) {
-      const enumType = value.enumType || value.EnumType || value.Type || value.type;
-      const enumValue = value.value || value.Value || value.name || value.Name;
-      if (enumType && enumValue !== undefined) {
-        return {
-          __type: "Enum",
-          enumType: String(enumType).replace(/^Enum\./, ""),
-          value: enumValue
-        };
-      }
-    }
-    return value;
-  }
-  return value;
-}
-
-export function convertImplicitRojoProperty(propName: string, val: any): any {
-  if (val === null || val === undefined) {
-    return null;
-  }
-  if (typeof val === "object" && !Array.isArray(val) && "Type" in val && "Value" in val) {
-    return convertExplicitRojoProperty(val.Type, val.Value);
-  }
-  if (typeof val === "object" && !Array.isArray(val) && "type" in val && "value" in val) {
-    return convertExplicitRojoProperty(val.type, val.value);
-  }
-
-  if (Array.isArray(val)) {
-    const allNumbers = val.every(v => typeof v === 'number');
-    if (allNumbers) {
-      const lowerName = propName.toLowerCase();
-      if (val.length === 12) {
-        return { __type: "CFrame", components: val };
-      }
-      if (val.length === 3) {
-        if (lowerName.includes("color")) {
-          if (val.some(v => v > 1.0)) {
-            return { __type: "Color3uint8", r: val[0], g: val[1], b: val[2] };
-          }
-          return { __type: "Color3", r: val[0], g: val[1], b: val[2] };
-        }
-        return { __type: "Vector3", x: val[0], y: val[1], z: val[2] };
-      }
-      if (val.length === 2) {
-        if (lowerName.includes("range")) {
-          return { __type: "NumberRange", min: val[0], max: val[1] };
-        }
-        if (lowerName.includes("udim") || lowerName.includes("size") || lowerName.includes("position")) {
-          return { __type: "UDim", scale: val[0], offset: val[1] };
-        }
-        return { __type: "Vector2", x: val[0], y: val[1] };
-      }
-      if (val.length === 4) {
-        if (lowerName.includes("rect")) {
-          return { __type: "Rect", minX: val[0], minY: val[1], maxX: val[2], maxY: val[3] };
-        }
-        return { __type: "UDim2", xScale: val[0], xOffset: val[1], yScale: val[2], yOffset: val[3] };
-      }
-    }
-  }
-
-  if (typeof val === "object" && val !== null) {
-    const copy: Record<string, any> = {};
-    for (const [k, v] of Object.entries(val)) {
-      copy[k] = convertImplicitRojoProperty(k, v);
-    }
-    return copy;
-  }
-
-  return val;
-}
-
-/**
- * Builds InstanceData[] from a Rojo-style default.project.json (compat layer).
- */
 export class RojoSnapshotBuilder {
   private projectFile: string;
   private cwd: string;
@@ -185,16 +54,10 @@ export class RojoSnapshotBuilder {
 
     log.debug(`destPrefix: ${this.destPrefix.join("/")}`);
 
-    // If the root of the project tree doesn't have a $className of "Datamodel", the Rojo project is not a Place and
-    // we cannot guess the root of the emitted tree.
     if (
       (!tree.$className || tree.$className !== "Datamodel") &&
       (!this.destPrefix || this.destPrefix.length === 0)
     ) {
-      /**
-       * Rojo error:
-       * Cannot sync a model as a place. Ensure Rojo is serving a project file that has a DataModel at the root of its tree and try again.
-       */
       log.error(
         `Cannot build Rojo compatibility snapshot: project file does not have a Datamodel root.`,
       );
@@ -234,7 +97,6 @@ export class RojoSnapshotBuilder {
         );
         const source = await fs.readFile(absRoot, "utf-8");
 
-        // If the root is a file, it becomes the single instance emitted at the destPrefix (or root if no prefix).
         const destPath =
           this.destPrefix.length === 0
             ? [scriptName]
@@ -261,12 +123,10 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    // Walk any children defined in the root of the project tree (if $path is not a file)
     if (hasChildren) {
       await this.walkTree(tree, [], projectDir, results);
     }
 
-    // Stable ordering: shallow-first, then lexical for determinism
     results.sort((a, b) => {
       if (a.path.length !== b.path.length) {
         return a.path.length - b.path.length;
@@ -393,7 +253,6 @@ export class RojoSnapshotBuilder {
   ): Promise<void> {
     if (typeof node !== "object" || node === null) return;
 
-    // Check for $path
     const pathHint = node.$path || node.path;
     if (typeof pathHint === "string") {
       const absPath = path.resolve(baseDir, pathHint);
@@ -442,8 +301,7 @@ export class RojoSnapshotBuilder {
     }
 
     const className = node.ClassName || node.className || node.$className || "Folder";
-    
-    // Resolve properties
+
     const rawProperties = node.Properties || node.properties || node.$properties;
     const properties: Record<string, any> = {};
     if (rawProperties && typeof rawProperties === "object") {
@@ -452,16 +310,14 @@ export class RojoSnapshotBuilder {
       }
     }
 
-    // Resolve attributes
     const rawAttributes = node.Attributes || node.attributes || node.$attributes;
     const attributes: Record<string, any> = {};
     if (rawAttributes && typeof rawAttributes === "object") {
       for (const [k, v] of Object.entries(rawAttributes)) {
-        attributes[k] = v;
+        attributes[k] = convertImplicitRojoProperty(k, v);
       }
     }
 
-    // Resolve tags
     const rawTags = node.Tags || node.tags || node.$tags;
     let tags: string[] | undefined = undefined;
     if (Array.isArray(rawTags)) {
@@ -488,7 +344,6 @@ export class RojoSnapshotBuilder {
     this.moduleContainers.add(currentPath.join("/"));
     results.push(instance);
 
-    // Recursively parse children
     const rawChildren = node.Children || node.children || node.$children;
     if (Array.isArray(rawChildren)) {
       for (let i = 0; i < rawChildren.length; i++) {
@@ -578,7 +433,6 @@ export class RojoSnapshotBuilder {
           results.push(...modelInstances);
         }
 
-        // Recurse into children defined in JSON
         for (const [childName, childValue] of Object.entries(node)) {
           if (childName.startsWith("$")) continue;
           if (typeof childValue !== "object" || childValue === null) continue;
@@ -674,7 +528,6 @@ export class RojoSnapshotBuilder {
       });
     }
 
-    // Recurse into children defined in JSON
     for (const [childName, childValue] of Object.entries(node)) {
       if (childName.startsWith("$")) continue;
       if (typeof childValue !== "object" || childValue === null) continue;
@@ -687,7 +540,6 @@ export class RojoSnapshotBuilder {
       );
     }
 
-    // Walk filesystem for $path mappings
     if (absPath && pathKind === "dir") {
       await this.walkDirectory(absPath, pathSegments, results, definedChildren);
     }
@@ -701,7 +553,6 @@ export class RojoSnapshotBuilder {
       return node.$className;
     }
     if (pathSegments.length === 1) {
-      // Service root
       return pathSegments[0];
     }
     return "Folder";
@@ -718,7 +569,6 @@ export class RojoSnapshotBuilder {
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
     const initCandidates = this.getInitCandidates();
 
-    // If this directory has an init, the directory becomes that script; children attach under it
     const initEntry = entries.find(
       (e) => e.isFile() && initCandidates.includes(e.name),
     );
@@ -777,7 +627,6 @@ export class RojoSnapshotBuilder {
       this.ensureFolder(destPath, results);
     }
 
-    // Sub-project override
     const subProjectPath = path.join(dirPath, "default.project.json");
     if (await this.exists(subProjectPath)) {
       const previousProjectFile = this.projectFile;
@@ -798,7 +647,6 @@ export class RojoSnapshotBuilder {
       const fullPath = path.join(dirPath, entry.name);
       if (this.isIgnored(fullPath)) continue;
 
-      // Skip entries explicitly defined in the project tree
       if (definedChildren.has(entry.name)) {
         continue;
       }
@@ -846,7 +694,6 @@ export class RojoSnapshotBuilder {
         continue;
       }
 
-      // Skip init files here (handled earlier)
       if (initCandidates.includes(entry.name)) {
         continue;
       }
@@ -890,15 +737,11 @@ export class RojoSnapshotBuilder {
     }
   }
 
-  /**
-   * Ensure a Folder chain exists for the given path.
-   */
   private ensureFolder(pathSegments: string[], results: InstanceData[]): void {
     if (pathSegments.length === 0) return;
     const key = pathSegments.join("/");
     if (this.moduleContainers.has(key)) return;
     if (this.emittedFolders.has(key)) return;
-    // ensure parents first
     this.ensureFolder(pathSegments.slice(0, -1), results);
     this.emittedFolders.add(key);
     results.push({

--- a/src/snapshot/rojo/builder.ts
+++ b/src/snapshot/rojo/builder.ts
@@ -684,7 +684,6 @@ export class RojoSnapshotBuilder {
       }
 
       if (entry.isDirectory()) {
-        this.ensureFolder([...destPath, entry.name], results);
         await this.walkDirectory(
           fullPath,
           [...destPath, entry.name],

--- a/src/snapshot/rojo/convert.ts
+++ b/src/snapshot/rojo/convert.ts
@@ -5,7 +5,12 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
       return { __type: "Vector3", x: value[0], y: value[1], z: value[2] };
     }
     if (typeof value === "object" && value !== null) {
-      return { __type: "Vector3", x: value.x ?? value.X ?? 0, y: value.y ?? value.Y ?? 0, z: value.z ?? value.Z ?? 0 };
+      return {
+        __type: "Vector3",
+        x: value.x ?? value.X ?? 0,
+        y: value.y ?? value.Y ?? 0,
+        z: value.z ?? value.Z ?? 0,
+      };
     }
   }
   if (normalizedType === "vector2") {
@@ -13,7 +18,11 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
       return { __type: "Vector2", x: value[0], y: value[1] };
     }
     if (typeof value === "object" && value !== null) {
-      return { __type: "Vector2", x: value.x ?? value.X ?? 0, y: value.y ?? value.Y ?? 0 };
+      return {
+        __type: "Vector2",
+        x: value.x ?? value.X ?? 0,
+        y: value.y ?? value.Y ?? 0,
+      };
     }
   }
   if (normalizedType === "vector2int16") {
@@ -48,11 +57,20 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
   }
   if (normalizedType === "udim2") {
     if (Array.isArray(value) && value.length === 4) {
-      return { __type: "UDim2", xScale: value[0], xOffset: value[1], yScale: value[2], yOffset: value[3] };
+      return {
+        __type: "UDim2",
+        xScale: value[0],
+        xOffset: value[1],
+        yScale: value[2],
+        yOffset: value[3],
+      };
     }
   }
   if (normalizedType === "brickcolor") {
-    return { __type: "BrickColor", number: typeof value === "number" ? value : 0 };
+    return {
+      __type: "BrickColor",
+      number: typeof value === "number" ? value : 0,
+    };
   }
   if (normalizedType === "numberrange") {
     if (Array.isArray(value) && value.length === 2) {
@@ -66,7 +84,11 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
           return { time: kp[0], value: kp[1], envelope: kp[2] ?? 0 };
         }
         if (typeof kp === "object" && kp !== null) {
-          return { time: kp.time ?? kp.Time ?? 0, value: kp.value ?? kp.Value ?? 0, envelope: kp.envelope ?? kp.Envelope ?? 0 };
+          return {
+            time: kp.time ?? kp.Time ?? 0,
+            value: kp.value ?? kp.Value ?? 0,
+            envelope: kp.envelope ?? kp.Envelope ?? 0,
+          };
         }
         return { time: 0, value: Number(kp), envelope: 0 };
       });
@@ -77,12 +99,20 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
     if (Array.isArray(value)) {
       const keypoints = value.map((kp: any) => {
         if (Array.isArray(kp)) {
-          return { time: kp[0], value: [kp[1], kp[2], kp[3]], envelope: kp[4] ?? 0 };
+          return {
+            time: kp[0],
+            value: [kp[1], kp[2], kp[3]],
+            envelope: kp[4] ?? 0,
+          };
         }
         if (typeof kp === "object" && kp !== null) {
           const c = kp.value ?? kp.Value;
           const color = Array.isArray(c) ? c : [1, 1, 1];
-          return { time: kp.time ?? kp.Time ?? 0, value: color, envelope: kp.envelope ?? kp.Envelope ?? 0 };
+          return {
+            time: kp.time ?? kp.Time ?? 0,
+            value: color,
+            envelope: kp.envelope ?? kp.Envelope ?? 0,
+          };
         }
         return { time: 0, value: [1, 1, 1], envelope: 0 };
       });
@@ -92,10 +122,26 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
   if (normalizedType === "rect") {
     if (Array.isArray(value)) {
       if (value.length === 4) {
-        return { __type: "Rect", minX: value[0], minY: value[1], maxX: value[2], maxY: value[3] };
+        return {
+          __type: "Rect",
+          minX: value[0],
+          minY: value[1],
+          maxX: value[2],
+          maxY: value[3],
+        };
       }
-      if (value.length === 2 && Array.isArray(value[0]) && Array.isArray(value[1])) {
-        return { __type: "Rect", minX: value[0][0], minY: value[0][1], maxX: value[1][0], maxY: value[1][1] };
+      if (
+        value.length === 2 &&
+        Array.isArray(value[0]) &&
+        Array.isArray(value[1])
+      ) {
+        return {
+          __type: "Rect",
+          minX: value[0][0],
+          minY: value[0][1],
+          maxX: value[1][0],
+          maxY: value[1][1],
+        };
       }
     }
   }
@@ -107,7 +153,8 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
         friction: value.Friction ?? value.friction ?? 0.5,
         elasticity: value.Elasticity ?? value.elasticity ?? 0.3,
         frictionWeight: value.FrictionWeight ?? value.frictionWeight ?? 1.0,
-        elasticityWeight: value.ElasticityWeight ?? value.elasticityWeight ?? 1.0,
+        elasticityWeight:
+          value.ElasticityWeight ?? value.elasticityWeight ?? 1.0,
       };
     }
   }
@@ -139,10 +186,20 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
       const originValue = value.origin ?? value.Origin;
       const directionValue = value.direction ?? value.Direction;
       const origin = Array.isArray(originValue)
-        ? { __type: "Vector3", x: originValue[0], y: originValue[1], z: originValue[2] }
+        ? {
+            __type: "Vector3",
+            x: originValue[0],
+            y: originValue[1],
+            z: originValue[2],
+          }
         : { __type: "Vector3", x: 0, y: 0, z: 0 };
       const direction = Array.isArray(directionValue)
-        ? { __type: "Vector3", x: directionValue[0], y: directionValue[1], z: directionValue[2] }
+        ? {
+            __type: "Vector3",
+            x: directionValue[0],
+            y: directionValue[1],
+            z: directionValue[2],
+          }
         : { __type: "Vector3", x: 0, y: 0, z: 1 };
       return { __type: "Ray", origin, direction };
     }
@@ -153,8 +210,12 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
       const max = value.max ?? value.Max;
       return {
         __type: "Region3",
-        min: Array.isArray(min) ? { x: min[0], y: min[1], z: min[2] } : min ?? { x: 0, y: 0, z: 0 },
-        max: Array.isArray(max) ? { x: max[0], y: max[1], z: max[2] } : max ?? { x: 0, y: 0, z: 0 },
+        min: Array.isArray(min)
+          ? { x: min[0], y: min[1], z: min[2] }
+          : (min ?? { x: 0, y: 0, z: 0 }),
+        max: Array.isArray(max)
+          ? { x: max[0], y: max[1], z: max[2] }
+          : (max ?? { x: 0, y: 0, z: 0 }),
       };
     }
   }
@@ -164,8 +225,12 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
       const max = value.max ?? value.Max;
       return {
         __type: "Region3int16",
-        min: Array.isArray(min) ? { x: min[0], y: min[1], z: min[2] } : min ?? { x: 0, y: 0, z: 0 },
-        max: Array.isArray(max) ? { x: max[0], y: max[1], z: max[2] } : max ?? { x: 0, y: 0, z: 0 },
+        min: Array.isArray(min)
+          ? { x: min[0], y: min[1], z: min[2] }
+          : (min ?? { x: 0, y: 0, z: 0 }),
+        max: Array.isArray(max)
+          ? { x: max[0], y: max[1], z: max[2] }
+          : (max ?? { x: 0, y: 0, z: 0 }),
       };
     }
   }
@@ -186,13 +251,14 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
   }
   if (normalizedType === "enum") {
     if (typeof value === "object" && value !== null) {
-      const enumType = value.enumType || value.EnumType || value.Type || value.type;
+      const enumType =
+        value.enumType || value.EnumType || value.Type || value.type;
       const enumValue = value.value || value.Value || value.name || value.Name;
       if (enumType && enumValue !== undefined) {
         return {
           __type: "Enum",
           enumType: String(enumType).replace(/^Enum\./, ""),
-          value: enumValue
+          value: enumValue,
         };
       }
     }
@@ -205,10 +271,20 @@ export function convertImplicitRojoProperty(propName: string, val: any): any {
   if (val === null || val === undefined) {
     return null;
   }
-  if (typeof val === "object" && !Array.isArray(val) && "Type" in val && "Value" in val) {
+  if (
+    typeof val === "object" &&
+    !Array.isArray(val) &&
+    "Type" in val &&
+    "Value" in val
+  ) {
     return convertExplicitRojoProperty(val.Type, val.Value);
   }
-  if (typeof val === "object" && !Array.isArray(val) && "type" in val && "value" in val) {
+  if (
+    typeof val === "object" &&
+    !Array.isArray(val) &&
+    "type" in val &&
+    "value" in val
+  ) {
     return convertExplicitRojoProperty(val.type, val.value);
   }
 
@@ -225,12 +301,12 @@ export function convertImplicitRojoProperty(propName: string, val: any): any {
   }
 
   if (Array.isArray(val)) {
-    const allStrings = val.every(v => typeof v === 'string');
+    const allStrings = val.every((v) => typeof v === "string");
     if (allStrings && val.length > 0) {
       return { __type: "Tags", tags: val.map(String) };
     }
 
-    const allNumbers = val.every(v => typeof v === 'number');
+    const allNumbers = val.every((v) => typeof v === "number");
     if (allNumbers) {
       const lowerName = propName.toLowerCase();
       if (val.length === 12) {
@@ -238,7 +314,7 @@ export function convertImplicitRojoProperty(propName: string, val: any): any {
       }
       if (val.length === 3) {
         if (lowerName.includes("color")) {
-          if (val.some(v => v > 1.0)) {
+          if (val.some((v) => v > 1.0)) {
             return { __type: "Color3uint8", r: val[0], g: val[1], b: val[2] };
           }
           return { __type: "Color3", r: val[0], g: val[1], b: val[2] };
@@ -249,38 +325,72 @@ export function convertImplicitRojoProperty(propName: string, val: any): any {
         if (lowerName.includes("range")) {
           return { __type: "NumberRange", min: val[0], max: val[1] };
         }
-        if (lowerName.includes("udim") || lowerName.includes("size") || lowerName.includes("position")) {
+        if (
+          lowerName.includes("udim") ||
+          lowerName.includes("size") ||
+          lowerName.includes("position")
+        ) {
           return { __type: "UDim", scale: val[0], offset: val[1] };
         }
         return { __type: "Vector2", x: val[0], y: val[1] };
       }
       if (val.length === 4) {
         if (lowerName.includes("rect")) {
-          return { __type: "Rect", minX: val[0], minY: val[1], maxX: val[2], maxY: val[3] };
+          return {
+            __type: "Rect",
+            minX: val[0],
+            minY: val[1],
+            maxX: val[2],
+            maxY: val[3],
+          };
         }
-        return { __type: "UDim2", xScale: val[0], xOffset: val[1], yScale: val[2], yOffset: val[3] };
+        return {
+          __type: "UDim2",
+          xScale: val[0],
+          xOffset: val[1],
+          yScale: val[2],
+          yOffset: val[3],
+        };
       }
     }
 
-    const allArraysOfTwo = val.every((v: any) => Array.isArray(v) && v.length >= 2 && v.every((n: any) => typeof n === 'number'));
+    const allArraysOfTwo = val.every(
+      (v: any) =>
+        Array.isArray(v) &&
+        v.length >= 2 &&
+        v.every((n: any) => typeof n === "number"),
+    );
     if (allArraysOfTwo && val.length > 0) {
       const sampleLen = val[0].length;
       if (sampleLen <= 3) {
         return {
           __type: "NumberSequence",
-          keypoints: val.map((kp: any) => ({ time: kp[0], value: kp[1], envelope: kp[2] ?? 0 }))
+          keypoints: val.map((kp: any) => ({
+            time: kp[0],
+            value: kp[1],
+            envelope: kp[2] ?? 0,
+          })),
         };
       }
       if (sampleLen >= 4) {
         return {
           __type: "ColorSequence",
-          keypoints: val.map((kp: any) => ({ time: kp[0], value: [kp[1], kp[2], kp[3]], envelope: kp[4] ?? 0 }))
+          keypoints: val.map((kp: any) => ({
+            time: kp[0],
+            value: [kp[1], kp[2], kp[3]],
+            envelope: kp[4] ?? 0,
+          })),
         };
       }
     }
 
-    const allKeypointObjects = val.every((v: any) =>
-      typeof v === "object" && v !== null && !Array.isArray(v) && ("time" in v || "Time" in v) && ("value" in v || "Value" in v)
+    const allKeypointObjects = val.every(
+      (v: any) =>
+        typeof v === "object" &&
+        v !== null &&
+        !Array.isArray(v) &&
+        ("time" in v || "Time" in v) &&
+        ("value" in v || "Value" in v),
     );
     if (allKeypointObjects && val.length > 0) {
       const first = val[0];
@@ -290,15 +400,15 @@ export function convertImplicitRojoProperty(propName: string, val: any): any {
           __type: "ColorSequence",
           keypoints: val.map((kp: any) => {
             const resolvedValue = kp.value ?? kp.Value;
-            
+
             return {
-                time: kp.time ?? kp.Time ?? 0,
-                value: Array.isArray(resolvedValue) 
-                    ? [resolvedValue[0], resolvedValue[1], resolvedValue[2]] 
-                    : [1, 1, 1],
-                envelope: kp.envelope ?? kp.Envelope ?? 0
+              time: kp.time ?? kp.Time ?? 0,
+              value: Array.isArray(resolvedValue)
+                ? [resolvedValue[0], resolvedValue[1], resolvedValue[2]]
+                : [1, 1, 1],
+              envelope: kp.envelope ?? kp.Envelope ?? 0,
             };
-          })
+          }),
         };
       }
       return {
@@ -306,8 +416,8 @@ export function convertImplicitRojoProperty(propName: string, val: any): any {
         keypoints: val.map((kp: any) => ({
           time: kp.time ?? kp.Time ?? 0,
           value: kp.value ?? kp.Value ?? 0,
-          envelope: kp.envelope ?? kp.Envelope ?? 0
-        }))
+          envelope: kp.envelope ?? kp.Envelope ?? 0,
+        })),
       };
     }
   }

--- a/src/snapshot/rojo/convert.ts
+++ b/src/snapshot/rojo/convert.ts
@@ -136,11 +136,13 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
   }
   if (normalizedType === "ray") {
     if (typeof value === "object" && value !== null) {
-      const origin = Array.isArray(value.origin ?? value.Origin)
-        ? { __type: "Vector3", x: value.origin[0], y: value.origin[1], z: value.origin[2] }
+      const originValue = value.origin ?? value.Origin;
+      const directionValue = value.direction ?? value.Direction;
+      const origin = Array.isArray(originValue)
+        ? { __type: "Vector3", x: originValue[0], y: originValue[1], z: originValue[2] }
         : { __type: "Vector3", x: 0, y: 0, z: 0 };
-      const direction = Array.isArray(value.direction ?? value.Direction)
-        ? { __type: "Vector3", x: value.direction[0], y: value.direction[1], z: value.direction[2] }
+      const direction = Array.isArray(directionValue)
+        ? { __type: "Vector3", x: directionValue[0], y: directionValue[1], z: directionValue[2] }
         : { __type: "Vector3", x: 0, y: 0, z: 1 };
       return { __type: "Ray", origin, direction };
     }

--- a/src/snapshot/rojo/convert.ts
+++ b/src/snapshot/rojo/convert.ts
@@ -288,11 +288,17 @@ export function convertImplicitRojoProperty(propName: string, val: any): any {
       if (Array.isArray(colorVal) && colorVal.length === 3) {
         return {
           __type: "ColorSequence",
-          keypoints: val.map((kp: any) => ({
-            time: kp.time ?? kp.Time ?? 0,
-            value: Array.isArray(kp.value ?? kp.Value) ? [kp.value[0], kp.value[1], kp.value[2]] : [1, 1, 1],
-            envelope: kp.envelope ?? kp.Envelope ?? 0
-          }))
+          keypoints: val.map((kp: any) => {
+            const resolvedValue = kp.value ?? kp.Value;
+            
+            return {
+                time: kp.time ?? kp.Time ?? 0,
+                value: Array.isArray(resolvedValue) 
+                    ? [resolvedValue[0], resolvedValue[1], resolvedValue[2]] 
+                    : [1, 1, 1],
+                envelope: kp.envelope ?? kp.Envelope ?? 0
+            };
+          })
         };
       }
       return {

--- a/src/snapshot/rojo/convert.ts
+++ b/src/snapshot/rojo/convert.ts
@@ -115,9 +115,9 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
     if (typeof value === "object" && value !== null) {
       return {
         __type: "Axes",
-        X: value.X ?? value.x ?? true,
-        Y: value.Y ?? value.y ?? true,
-        Z: value.Z ?? value.z ?? true,
+        x: value.X ?? value.x ?? true,
+        y: value.Y ?? value.y ?? true,
+        z: value.Z ?? value.z ?? true,
       };
     }
   }
@@ -125,19 +125,23 @@ function convertExplicitRojoProperty(typeStr: string, value: any): any {
     if (typeof value === "object" && value !== null) {
       return {
         __type: "Faces",
-        Top: value.Top ?? value.top ?? false,
-        Bottom: value.Bottom ?? value.bottom ?? false,
-        Left: value.Left ?? value.left ?? false,
-        Right: value.Right ?? value.right ?? false,
-        Front: value.Front ?? value.front ?? false,
-        Back: value.Back ?? value.back ?? false,
+        top: value.Top ?? value.top ?? false,
+        bottom: value.Bottom ?? value.bottom ?? false,
+        left: value.Left ?? value.left ?? false,
+        right: value.Right ?? value.right ?? false,
+        front: value.Front ?? value.front ?? false,
+        back: value.Back ?? value.back ?? false,
       };
     }
   }
   if (normalizedType === "ray") {
     if (typeof value === "object" && value !== null) {
-      const origin = Array.isArray(value.origin ?? value.Origin) ? { x: value.origin[0], y: value.origin[1], z: value.origin[2] } : { x: 0, y: 0, z: 0 };
-      const direction = Array.isArray(value.direction ?? value.Direction) ? { x: value.direction[0], y: value.direction[1], z: value.direction[2] } : { x: 0, y: 0, z: 1 };
+      const origin = Array.isArray(value.origin ?? value.Origin)
+        ? { __type: "Vector3", x: value.origin[0], y: value.origin[1], z: value.origin[2] }
+        : { __type: "Vector3", x: 0, y: 0, z: 0 };
+      const direction = Array.isArray(value.direction ?? value.Direction)
+        ? { __type: "Vector3", x: value.direction[0], y: value.direction[1], z: value.direction[2] }
+        : { __type: "Vector3", x: 0, y: 0, z: 1 };
       return { __type: "Ray", origin, direction };
     }
   }

--- a/src/snapshot/rojo/convert.ts
+++ b/src/snapshot/rojo/convert.ts
@@ -1,0 +1,321 @@
+function convertExplicitRojoProperty(typeStr: string, value: any): any {
+  const normalizedType = typeStr.toLowerCase();
+  if (normalizedType === "vector3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Vector3", x: value[0], y: value[1], z: value[2] };
+    }
+    if (typeof value === "object" && value !== null) {
+      return { __type: "Vector3", x: value.x ?? value.X ?? 0, y: value.y ?? value.Y ?? 0, z: value.z ?? value.Z ?? 0 };
+    }
+  }
+  if (normalizedType === "vector2") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "Vector2", x: value[0], y: value[1] };
+    }
+    if (typeof value === "object" && value !== null) {
+      return { __type: "Vector2", x: value.x ?? value.X ?? 0, y: value.y ?? value.Y ?? 0 };
+    }
+  }
+  if (normalizedType === "vector2int16") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "Vector2int16", x: value[0], y: value[1] };
+    }
+  }
+  if (normalizedType === "vector3int16") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Vector3int16", x: value[0], y: value[1], z: value[2] };
+    }
+  }
+  if (normalizedType === "color3") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "color3uint8") {
+    if (Array.isArray(value) && value.length === 3) {
+      return { __type: "Color3uint8", r: value[0], g: value[1], b: value[2] };
+    }
+  }
+  if (normalizedType === "cframe") {
+    if (Array.isArray(value)) {
+      return { __type: "CFrame", components: value };
+    }
+  }
+  if (normalizedType === "udim") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "UDim", scale: value[0], offset: value[1] };
+    }
+  }
+  if (normalizedType === "udim2") {
+    if (Array.isArray(value) && value.length === 4) {
+      return { __type: "UDim2", xScale: value[0], xOffset: value[1], yScale: value[2], yOffset: value[3] };
+    }
+  }
+  if (normalizedType === "brickcolor") {
+    return { __type: "BrickColor", number: typeof value === "number" ? value : 0 };
+  }
+  if (normalizedType === "numberrange") {
+    if (Array.isArray(value) && value.length === 2) {
+      return { __type: "NumberRange", min: value[0], max: value[1] };
+    }
+  }
+  if (normalizedType === "numbersequence") {
+    if (Array.isArray(value)) {
+      const keypoints = value.map((kp: any) => {
+        if (Array.isArray(kp)) {
+          return { time: kp[0], value: kp[1], envelope: kp[2] ?? 0 };
+        }
+        if (typeof kp === "object" && kp !== null) {
+          return { time: kp.time ?? kp.Time ?? 0, value: kp.value ?? kp.Value ?? 0, envelope: kp.envelope ?? kp.Envelope ?? 0 };
+        }
+        return { time: 0, value: Number(kp), envelope: 0 };
+      });
+      return { __type: "NumberSequence", keypoints };
+    }
+  }
+  if (normalizedType === "colorsequence") {
+    if (Array.isArray(value)) {
+      const keypoints = value.map((kp: any) => {
+        if (Array.isArray(kp)) {
+          return { time: kp[0], value: [kp[1], kp[2], kp[3]], envelope: kp[4] ?? 0 };
+        }
+        if (typeof kp === "object" && kp !== null) {
+          const c = kp.value ?? kp.Value;
+          const color = Array.isArray(c) ? c : [1, 1, 1];
+          return { time: kp.time ?? kp.Time ?? 0, value: color, envelope: kp.envelope ?? kp.Envelope ?? 0 };
+        }
+        return { time: 0, value: [1, 1, 1], envelope: 0 };
+      });
+      return { __type: "ColorSequence", keypoints };
+    }
+  }
+  if (normalizedType === "rect") {
+    if (Array.isArray(value)) {
+      if (value.length === 4) {
+        return { __type: "Rect", minX: value[0], minY: value[1], maxX: value[2], maxY: value[3] };
+      }
+      if (value.length === 2 && Array.isArray(value[0]) && Array.isArray(value[1])) {
+        return { __type: "Rect", minX: value[0][0], minY: value[0][1], maxX: value[1][0], maxY: value[1][1] };
+      }
+    }
+  }
+  if (normalizedType === "physicalproperties") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "PhysicalProperties",
+        density: value.Density ?? value.density ?? 0.7,
+        friction: value.Friction ?? value.friction ?? 0.5,
+        elasticity: value.Elasticity ?? value.elasticity ?? 0.3,
+        frictionWeight: value.FrictionWeight ?? value.frictionWeight ?? 1.0,
+        elasticityWeight: value.ElasticityWeight ?? value.elasticityWeight ?? 1.0,
+      };
+    }
+  }
+  if (normalizedType === "axes") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "Axes",
+        X: value.X ?? value.x ?? true,
+        Y: value.Y ?? value.y ?? true,
+        Z: value.Z ?? value.z ?? true,
+      };
+    }
+  }
+  if (normalizedType === "faces") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "Faces",
+        Top: value.Top ?? value.top ?? false,
+        Bottom: value.Bottom ?? value.bottom ?? false,
+        Left: value.Left ?? value.left ?? false,
+        Right: value.Right ?? value.right ?? false,
+        Front: value.Front ?? value.front ?? false,
+        Back: value.Back ?? value.back ?? false,
+      };
+    }
+  }
+  if (normalizedType === "ray") {
+    if (typeof value === "object" && value !== null) {
+      const origin = Array.isArray(value.origin ?? value.Origin) ? { x: value.origin[0], y: value.origin[1], z: value.origin[2] } : { x: 0, y: 0, z: 0 };
+      const direction = Array.isArray(value.direction ?? value.Direction) ? { x: value.direction[0], y: value.direction[1], z: value.direction[2] } : { x: 0, y: 0, z: 1 };
+      return { __type: "Ray", origin, direction };
+    }
+  }
+  if (normalizedType === "region3") {
+    if (typeof value === "object" && value !== null) {
+      const min = value.min ?? value.Min;
+      const max = value.max ?? value.Max;
+      return {
+        __type: "Region3",
+        min: Array.isArray(min) ? { x: min[0], y: min[1], z: min[2] } : min ?? { x: 0, y: 0, z: 0 },
+        max: Array.isArray(max) ? { x: max[0], y: max[1], z: max[2] } : max ?? { x: 0, y: 0, z: 0 },
+      };
+    }
+  }
+  if (normalizedType === "region3int16") {
+    if (typeof value === "object" && value !== null) {
+      const min = value.min ?? value.Min;
+      const max = value.max ?? value.Max;
+      return {
+        __type: "Region3int16",
+        min: Array.isArray(min) ? { x: min[0], y: min[1], z: min[2] } : min ?? { x: 0, y: 0, z: 0 },
+        max: Array.isArray(max) ? { x: max[0], y: max[1], z: max[2] } : max ?? { x: 0, y: 0, z: 0 },
+      };
+    }
+  }
+  if (normalizedType === "font") {
+    if (typeof value === "object" && value !== null) {
+      return {
+        __type: "Font",
+        family: value.Family ?? value.family ?? "",
+        weight: value.Weight ?? value.weight ?? "Regular",
+        style: value.Style ?? value.style ?? "Normal",
+      };
+    }
+  }
+  if (normalizedType === "tags") {
+    if (Array.isArray(value)) {
+      return { __type: "Tags", tags: value.map(String) };
+    }
+  }
+  if (normalizedType === "enum") {
+    if (typeof value === "object" && value !== null) {
+      const enumType = value.enumType || value.EnumType || value.Type || value.type;
+      const enumValue = value.value || value.Value || value.name || value.Name;
+      if (enumType && enumValue !== undefined) {
+        return {
+          __type: "Enum",
+          enumType: String(enumType).replace(/^Enum\./, ""),
+          value: enumValue
+        };
+      }
+    }
+    return value;
+  }
+  return value;
+}
+
+export function convertImplicitRojoProperty(propName: string, val: any): any {
+  if (val === null || val === undefined) {
+    return null;
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "Type" in val && "Value" in val) {
+    return convertExplicitRojoProperty(val.Type, val.Value);
+  }
+  if (typeof val === "object" && !Array.isArray(val) && "type" in val && "value" in val) {
+    return convertExplicitRojoProperty(val.type, val.value);
+  }
+
+  if (typeof val === "string") {
+    return val;
+  }
+
+  if (typeof val === "boolean") {
+    return val;
+  }
+
+  if (typeof val === "number") {
+    return val;
+  }
+
+  if (Array.isArray(val)) {
+    const allStrings = val.every(v => typeof v === 'string');
+    if (allStrings && val.length > 0) {
+      return { __type: "Tags", tags: val.map(String) };
+    }
+
+    const allNumbers = val.every(v => typeof v === 'number');
+    if (allNumbers) {
+      const lowerName = propName.toLowerCase();
+      if (val.length === 12) {
+        return { __type: "CFrame", components: val };
+      }
+      if (val.length === 3) {
+        if (lowerName.includes("color")) {
+          if (val.some(v => v > 1.0)) {
+            return { __type: "Color3uint8", r: val[0], g: val[1], b: val[2] };
+          }
+          return { __type: "Color3", r: val[0], g: val[1], b: val[2] };
+        }
+        return { __type: "Vector3", x: val[0], y: val[1], z: val[2] };
+      }
+      if (val.length === 2) {
+        if (lowerName.includes("range")) {
+          return { __type: "NumberRange", min: val[0], max: val[1] };
+        }
+        if (lowerName.includes("udim") || lowerName.includes("size") || lowerName.includes("position")) {
+          return { __type: "UDim", scale: val[0], offset: val[1] };
+        }
+        return { __type: "Vector2", x: val[0], y: val[1] };
+      }
+      if (val.length === 4) {
+        if (lowerName.includes("rect")) {
+          return { __type: "Rect", minX: val[0], minY: val[1], maxX: val[2], maxY: val[3] };
+        }
+        return { __type: "UDim2", xScale: val[0], xOffset: val[1], yScale: val[2], yOffset: val[3] };
+      }
+    }
+
+    const allArraysOfTwo = val.every((v: any) => Array.isArray(v) && v.length >= 2 && v.every((n: any) => typeof n === 'number'));
+    if (allArraysOfTwo && val.length > 0) {
+      const sampleLen = val[0].length;
+      if (sampleLen <= 3) {
+        return {
+          __type: "NumberSequence",
+          keypoints: val.map((kp: any) => ({ time: kp[0], value: kp[1], envelope: kp[2] ?? 0 }))
+        };
+      }
+      if (sampleLen >= 4) {
+        return {
+          __type: "ColorSequence",
+          keypoints: val.map((kp: any) => ({ time: kp[0], value: [kp[1], kp[2], kp[3]], envelope: kp[4] ?? 0 }))
+        };
+      }
+    }
+
+    const allKeypointObjects = val.every((v: any) =>
+      typeof v === "object" && v !== null && !Array.isArray(v) && ("time" in v || "Time" in v) && ("value" in v || "Value" in v)
+    );
+    if (allKeypointObjects && val.length > 0) {
+      const first = val[0];
+      const colorVal = first.value ?? first.Value;
+      if (Array.isArray(colorVal) && colorVal.length === 3) {
+        return {
+          __type: "ColorSequence",
+          keypoints: val.map((kp: any) => ({
+            time: kp.time ?? kp.Time ?? 0,
+            value: Array.isArray(kp.value ?? kp.Value) ? [kp.value[0], kp.value[1], kp.value[2]] : [1, 1, 1],
+            envelope: kp.envelope ?? kp.Envelope ?? 0
+          }))
+        };
+      }
+      return {
+        __type: "NumberSequence",
+        keypoints: val.map((kp: any) => ({
+          time: kp.time ?? kp.Time ?? 0,
+          value: kp.value ?? kp.Value ?? 0,
+          envelope: kp.envelope ?? kp.Envelope ?? 0
+        }))
+      };
+    }
+  }
+
+  if (typeof val === "object" && val !== null) {
+    if ("family" in val || "Family" in val) {
+      return {
+        __type: "Font",
+        family: val.Family ?? val.family ?? "",
+        weight: val.Weight ?? val.weight ?? "Regular",
+        style: val.Style ?? val.style ?? "Normal",
+      };
+    }
+
+    const copy: Record<string, any> = {};
+    for (const [k, v] of Object.entries(val)) {
+      copy[k] = convertImplicitRojoProperty(k, v);
+    }
+    return copy;
+  }
+
+  return val;
+}

--- a/src/snapshot/rojo/index.ts
+++ b/src/snapshot/rojo/index.ts
@@ -1,0 +1,2 @@
+export { RojoSnapshotBuilder } from "./builder.js";
+export type { RojoSnapshotOptions } from "./builder.js";

--- a/src/tests/daemon.test.ts
+++ b/src/tests/daemon.test.ts
@@ -179,6 +179,28 @@ test("deleted removes files and updates sourcemap", async () => {
 
     // File should be removed
     assert.strictEqual(fs.existsSync(filePath), false, "file was deleted");
+
+    // Sourcemap should also be pruned for the deleted node/path
+    const sourcemapRaw = fs.readFileSync(config.sourcemapPath, "utf8");
+    const sourcemap = JSON.parse(sourcemapRaw);
+    assert.notStrictEqual(sourcemapRaw.includes('"guid": "sdel"'), true);
+    assert.notStrictEqual(sourcemapRaw.includes('"name": "ToDelete"'), true);
+    const hasDeletedPath = (node: any, pathSegments: string[]): boolean => {
+      if (!node || !Array.isArray(node.children)) return false;
+      for (const child of node.children) {
+        if (child.name === pathSegments[0]) {
+          if (pathSegments.length === 1) return true;
+          if (hasDeletedPath(child, pathSegments.slice(1))) return true;
+        }
+        if (hasDeletedPath(child, pathSegments)) return true;
+      }
+      return false;
+    };
+    assert.strictEqual(
+      hasDeletedPath(sourcemap, ["ReplicatedStorage", "Modules", "ToDelete"]),
+      false,
+      "deleted path removed from sourcemap",
+    );
   } finally {
     await daemon?.stop();
     config.syncDir = prevSyncDir;

--- a/src/tests/daemon.test.ts
+++ b/src/tests/daemon.test.ts
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { SyncDaemon } from "../index.js";
+import { config } from "../config.js";
+
+function makeTempDir(prefix = "azul-test-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("fullSnapshot writes scripts, generates sourcemap, and removes orphans", async () => {
+  const tmp = makeTempDir();
+  // Configure daemon to use our temp dir and an ephemeral port
+  config.syncDir = tmp;
+  config.sourcemapPath = path.join(tmp, "sourcemap.json");
+  config.port = 0;
+  config.deleteOrphansOnConnect = true;
+
+  // Create an orphan file that should be removed on snapshot
+  const orphanDir = path.join(tmp, "extra");
+  fs.mkdirSync(orphanDir, { recursive: true });
+  const orphanPath = path.join(orphanDir, "orphan.luau");
+  fs.writeFileSync(orphanPath, "print('i am orphan')", "utf8");
+  assert.ok(fs.existsSync(orphanPath), "orphan created");
+
+  const daemon = new SyncDaemon();
+
+  const instances = [
+    {
+      guid: "r1",
+      className: "Folder",
+      name: "ReplicatedStorage",
+      path: ["ReplicatedStorage"],
+    },
+    {
+      guid: "m1",
+      className: "Folder",
+      name: "Modules",
+      path: ["ReplicatedStorage", "Modules"],
+    },
+    {
+      guid: "s1",
+      className: "ModuleScript",
+      name: "Foo",
+      path: ["ReplicatedStorage", "Modules", "Foo"],
+      source: "print('hello')",
+    },
+  ];
+
+  // Send full snapshot
+  (daemon as any).handleStudioMessage({
+    type: "fullSnapshot",
+    data: instances,
+  });
+
+  const expectedFile = path.join(
+    tmp,
+    "ReplicatedStorage",
+    "Modules",
+    "Foo.luau",
+  );
+  assert.ok(fs.existsSync(expectedFile), "script file was written");
+
+  assert.ok(fs.existsSync(config.sourcemapPath), "sourcemap was generated");
+  const sourcemap = JSON.parse(fs.readFileSync(config.sourcemapPath, "utf8"));
+  assert.strictEqual(sourcemap.name, "Game");
+
+  // Orphan file should have been removed
+  assert.strictEqual(fs.existsSync(orphanPath), false, "orphan file removed");
+
+  await daemon.stop();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test("scriptChanged creates file when node missing", async () => {
+  const tmp = makeTempDir();
+  config.syncDir = tmp;
+  config.sourcemapPath = path.join(tmp, "sourcemap.json");
+  config.port = 0;
+
+  const daemon = new SyncDaemon();
+
+  const msg = {
+    type: "scriptChanged",
+    data: {
+      guid: "new1",
+      path: ["ReplicatedStorage", "Modules", "Bar"],
+      className: "ModuleScript",
+      source: "print('bar')",
+    },
+  } as any;
+
+  (daemon as any).handleStudioMessage(msg);
+
+  const expected = path.join(tmp, "ReplicatedStorage", "Modules", "Bar.luau");
+  assert.ok(fs.existsSync(expected), "scriptChanged created file");
+
+  await daemon.stop();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test("deleted removes files and updates sourcemap", async () => {
+  const tmp = makeTempDir();
+  config.syncDir = tmp;
+  config.sourcemapPath = path.join(tmp, "sourcemap.json");
+  config.port = 0;
+
+  const daemon = new SyncDaemon();
+
+  // Create snapshot with one script
+  const instances = [
+    {
+      guid: "r1",
+      className: "Folder",
+      name: "ReplicatedStorage",
+      path: ["ReplicatedStorage"],
+    },
+    {
+      guid: "m1",
+      className: "Folder",
+      name: "Modules",
+      path: ["ReplicatedStorage", "Modules"],
+    },
+    {
+      guid: "sdel",
+      className: "ModuleScript",
+      name: "ToDelete",
+      path: ["ReplicatedStorage", "Modules", "ToDelete"],
+      source: "print('bye')",
+    },
+  ];
+
+  (daemon as any).handleStudioMessage({
+    type: "fullSnapshot",
+    data: instances,
+  });
+  const filePath = path.join(
+    tmp,
+    "ReplicatedStorage",
+    "Modules",
+    "ToDelete.luau",
+  );
+  assert.ok(fs.existsSync(filePath), "initial file exists");
+  assert.ok(fs.existsSync(config.sourcemapPath), "sourcemap exists");
+
+  // Send delete
+  (daemon as any).handleStudioMessage({
+    type: "deleted",
+    data: { guid: "sdel" },
+  });
+
+  // File should be removed
+  assert.strictEqual(fs.existsSync(filePath), false, "file was deleted");
+
+  await daemon.stop();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/src/tests/daemon.test.ts
+++ b/src/tests/daemon.test.ts
@@ -13,148 +13,177 @@ function makeTempDir(prefix = "azul-test-") {
 
 test("fullSnapshot writes scripts, generates sourcemap, and removes orphans", async () => {
   const tmp = makeTempDir();
-  // Configure daemon to use our temp dir and an ephemeral port
-  config.syncDir = tmp;
-  config.sourcemapPath = path.join(tmp, "sourcemap.json");
-  config.port = 0;
-  config.deleteOrphansOnConnect = true;
+  const prevSyncDir = config.syncDir;
+  const prevSourcemapPath = config.sourcemapPath;
+  const prevPort = config.port;
+  const prevDeleteOrphansOnConnect = config.deleteOrphansOnConnect;
+  let daemon: SyncDaemon | undefined;
+  try {
+    // Configure daemon to use our temp dir and an ephemeral port
+    config.syncDir = tmp;
+    config.sourcemapPath = path.join(tmp, "sourcemap.json");
+    config.port = 0;
+    config.deleteOrphansOnConnect = true;
 
-  // Create an orphan file that should be removed on snapshot
-  const orphanDir = path.join(tmp, "extra");
-  fs.mkdirSync(orphanDir, { recursive: true });
-  const orphanPath = path.join(orphanDir, "orphan.luau");
-  fs.writeFileSync(orphanPath, "print('i am orphan')", "utf8");
-  assert.ok(fs.existsSync(orphanPath), "orphan created");
+    // Create an orphan file that should be removed on snapshot
+    const orphanDir = path.join(tmp, "extra");
+    fs.mkdirSync(orphanDir, { recursive: true });
+    const orphanPath = path.join(orphanDir, "orphan.luau");
+    fs.writeFileSync(orphanPath, "print('i am orphan')", "utf8");
+    assert.ok(fs.existsSync(orphanPath), "orphan created");
 
-  const daemon = new SyncDaemon();
+    daemon = new SyncDaemon();
 
-  const instances = [
-    {
-      guid: "r1",
-      className: "Folder",
-      name: "ReplicatedStorage",
-      path: ["ReplicatedStorage"],
-    },
-    {
-      guid: "m1",
-      className: "Folder",
-      name: "Modules",
-      path: ["ReplicatedStorage", "Modules"],
-    },
-    {
-      guid: "s1",
-      className: "ModuleScript",
-      name: "Foo",
-      path: ["ReplicatedStorage", "Modules", "Foo"],
-      source: "print('hello')",
-    },
-  ];
+    const instances = [
+      {
+        guid: "r1",
+        className: "Folder",
+        name: "ReplicatedStorage",
+        path: ["ReplicatedStorage"],
+      },
+      {
+        guid: "m1",
+        className: "Folder",
+        name: "Modules",
+        path: ["ReplicatedStorage", "Modules"],
+      },
+      {
+        guid: "s1",
+        className: "ModuleScript",
+        name: "Foo",
+        path: ["ReplicatedStorage", "Modules", "Foo"],
+        source: "print('hello')",
+      },
+    ];
 
-  // Send full snapshot
-  (daemon as any).handleStudioMessage({
-    type: "fullSnapshot",
-    data: instances,
-  });
+    // Send full snapshot
+    (daemon as any).handleStudioMessage({
+      type: "fullSnapshot",
+      data: instances,
+    });
 
-  const expectedFile = path.join(
-    tmp,
-    "ReplicatedStorage",
-    "Modules",
-    "Foo.luau",
-  );
-  assert.ok(fs.existsSync(expectedFile), "script file was written");
+    const expectedFile = path.join(
+      tmp,
+      "ReplicatedStorage",
+      "Modules",
+      "Foo.luau",
+    );
+    assert.ok(fs.existsSync(expectedFile), "script file was written");
 
-  assert.ok(fs.existsSync(config.sourcemapPath), "sourcemap was generated");
-  const sourcemap = JSON.parse(fs.readFileSync(config.sourcemapPath, "utf8"));
-  assert.strictEqual(sourcemap.name, "Game");
+    assert.ok(fs.existsSync(config.sourcemapPath), "sourcemap was generated");
+    const sourcemap = JSON.parse(fs.readFileSync(config.sourcemapPath, "utf8"));
+    assert.strictEqual(sourcemap.name, "Game");
 
-  // Orphan file should have been removed
-  assert.strictEqual(fs.existsSync(orphanPath), false, "orphan file removed");
-
-  await daemon.stop();
-  fs.rmSync(tmp, { recursive: true, force: true });
+    // Orphan file should have been removed
+    assert.strictEqual(fs.existsSync(orphanPath), false, "orphan file removed");
+  } finally {
+    await daemon?.stop();
+    config.syncDir = prevSyncDir;
+    config.sourcemapPath = prevSourcemapPath;
+    config.port = prevPort;
+    config.deleteOrphansOnConnect = prevDeleteOrphansOnConnect;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test("scriptChanged creates file when node missing", async () => {
   const tmp = makeTempDir();
-  config.syncDir = tmp;
-  config.sourcemapPath = path.join(tmp, "sourcemap.json");
-  config.port = 0;
+  const prevSyncDir = config.syncDir;
+  const prevSourcemapPath = config.sourcemapPath;
+  const prevPort = config.port;
+  let daemon: SyncDaemon | undefined;
+  try {
+    config.syncDir = tmp;
+    config.sourcemapPath = path.join(tmp, "sourcemap.json");
+    config.port = 0;
 
-  const daemon = new SyncDaemon();
+    daemon = new SyncDaemon();
 
-  const msg = {
-    type: "scriptChanged",
-    data: {
-      guid: "new1",
-      path: ["ReplicatedStorage", "Modules", "Bar"],
-      className: "ModuleScript",
-      source: "print('bar')",
-    },
-  } as any;
+    const msg = {
+      type: "scriptChanged",
+      data: {
+        guid: "new1",
+        path: ["ReplicatedStorage", "Modules", "Bar"],
+        className: "ModuleScript",
+        source: "print('bar')",
+      },
+    } as any;
 
-  (daemon as any).handleStudioMessage(msg);
+    (daemon as any).handleStudioMessage(msg);
 
-  const expected = path.join(tmp, "ReplicatedStorage", "Modules", "Bar.luau");
-  assert.ok(fs.existsSync(expected), "scriptChanged created file");
-
-  await daemon.stop();
-  fs.rmSync(tmp, { recursive: true, force: true });
+    const expected = path.join(tmp, "ReplicatedStorage", "Modules", "Bar.luau");
+    assert.ok(fs.existsSync(expected), "scriptChanged created file");
+  } finally {
+    await daemon?.stop();
+    config.syncDir = prevSyncDir;
+    config.sourcemapPath = prevSourcemapPath;
+    config.port = prevPort;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });
 
 test("deleted removes files and updates sourcemap", async () => {
   const tmp = makeTempDir();
-  config.syncDir = tmp;
-  config.sourcemapPath = path.join(tmp, "sourcemap.json");
-  config.port = 0;
+  const prevSyncDir = config.syncDir;
+  const prevSourcemapPath = config.sourcemapPath;
+  const prevPort = config.port;
+  let daemon: SyncDaemon | undefined;
+  try {
+    config.syncDir = tmp;
+    config.sourcemapPath = path.join(tmp, "sourcemap.json");
+    config.port = 0;
 
-  const daemon = new SyncDaemon();
+    daemon = new SyncDaemon();
 
-  // Create snapshot with one script
-  const instances = [
-    {
-      guid: "r1",
-      className: "Folder",
-      name: "ReplicatedStorage",
-      path: ["ReplicatedStorage"],
-    },
-    {
-      guid: "m1",
-      className: "Folder",
-      name: "Modules",
-      path: ["ReplicatedStorage", "Modules"],
-    },
-    {
-      guid: "sdel",
-      className: "ModuleScript",
-      name: "ToDelete",
-      path: ["ReplicatedStorage", "Modules", "ToDelete"],
-      source: "print('bye')",
-    },
-  ];
+    // Create snapshot with one script
+    const instances = [
+      {
+        guid: "r1",
+        className: "Folder",
+        name: "ReplicatedStorage",
+        path: ["ReplicatedStorage"],
+      },
+      {
+        guid: "m1",
+        className: "Folder",
+        name: "Modules",
+        path: ["ReplicatedStorage", "Modules"],
+      },
+      {
+        guid: "sdel",
+        className: "ModuleScript",
+        name: "ToDelete",
+        path: ["ReplicatedStorage", "Modules", "ToDelete"],
+        source: "print('bye')",
+      },
+    ];
 
-  (daemon as any).handleStudioMessage({
-    type: "fullSnapshot",
-    data: instances,
-  });
-  const filePath = path.join(
-    tmp,
-    "ReplicatedStorage",
-    "Modules",
-    "ToDelete.luau",
-  );
-  assert.ok(fs.existsSync(filePath), "initial file exists");
-  assert.ok(fs.existsSync(config.sourcemapPath), "sourcemap exists");
+    (daemon as any).handleStudioMessage({
+      type: "fullSnapshot",
+      data: instances,
+    });
+    const filePath = path.join(
+      tmp,
+      "ReplicatedStorage",
+      "Modules",
+      "ToDelete.luau",
+    );
+    assert.ok(fs.existsSync(filePath), "initial file exists");
+    assert.ok(fs.existsSync(config.sourcemapPath), "sourcemap exists");
 
-  // Send delete
-  (daemon as any).handleStudioMessage({
-    type: "deleted",
-    data: { guid: "sdel" },
-  });
+    // Send delete
+    (daemon as any).handleStudioMessage({
+      type: "deleted",
+      data: { guid: "sdel" },
+    });
 
-  // File should be removed
-  assert.strictEqual(fs.existsSync(filePath), false, "file was deleted");
-
-  await daemon.stop();
-  fs.rmSync(tmp, { recursive: true, force: true });
+    // File should be removed
+    assert.strictEqual(fs.existsSync(filePath), false, "file was deleted");
+  } finally {
+    await daemon?.stop();
+    config.syncDir = prevSyncDir;
+    config.sourcemapPath = prevSourcemapPath;
+    config.port = prevPort;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });

--- a/src/tests/pack.test.ts
+++ b/src/tests/pack.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PackCommand } from "../pack.js";
+import { config } from "../config.js";
+
+// Use ephemeral IPC port to avoid collisions
+config.port = 0;
+
+test("PackCommand regenerate and pack produce _azul metadata and pack nodes", () => {
+  const pack = new PackCommand({});
+
+  const snapshot = [
+    {
+      guid: "groot",
+      className: "ReplicatedStorage",
+      name: "ReplicatedStorage",
+      path: ["ReplicatedStorage"],
+    },
+    {
+      guid: "gmod",
+      className: "Folder",
+      name: "ModuleA",
+      path: ["ReplicatedStorage", "ModuleA"],
+      parentGuid: "groot",
+    },
+    {
+      guid: "gfoo",
+      className: "ModuleScript",
+      name: "Foo",
+      path: ["ReplicatedStorage", "ModuleA", "Foo"],
+      parentGuid: "gmod",
+      properties: { X: 1 },
+      attributes: { A: true },
+      tags: ["t"],
+    },
+  ];
+
+  const root = (pack as any).regenerateSourcemap(snapshot, null);
+  const packed = (pack as any).packIntoSourcemap(snapshot, root);
+  assert.strictEqual(typeof root._azul?.packedAt, "string");
+  assert.strictEqual(root._azul?.packVersion, 1);
+  assert.strictEqual(typeof packed, "number");
+});

--- a/src/tests/property_loader.test.ts
+++ b/src/tests/property_loader.test.ts
@@ -35,6 +35,9 @@ test("buildInstancesFromSourcemap reads file contents and applySourcemapProperti
                 name: "Foo",
                 className: "ModuleScript",
                 guid: "g1",
+                properties: { MyProp: 123 },
+                attributes: { Build: "dev" },
+                tags: ["Client"],
                 filePaths: [scriptFile],
               },
             ],
@@ -52,11 +55,18 @@ test("buildInstancesFromSourcemap reads file contents and applySourcemapProperti
   const foo = instances!.find((i) => i.name === "Foo");
   assert.ok(foo?.source?.includes("smap"));
 
-  // Add properties to instance and pack
-  foo!.properties = { MyProp: 123 };
+  // Clear fields so merge/write-back path must restore them from sourcemap index
+  foo!.properties = undefined;
+  foo!.attributes = undefined;
+  foo!.tags = undefined;
+
   const index = loadSourcemapPropertyIndex(smPath);
+  assert.ok(index, "property index loaded");
   const applied = applySourcemapProperties(instances!, index);
-  assert.strictEqual(typeof applied, "number");
+  assert.strictEqual(applied, 1);
+  assert.deepStrictEqual(foo!.properties, { MyProp: 123 });
+  assert.deepStrictEqual(foo!.attributes, { Build: "dev" });
+  assert.deepStrictEqual(foo!.tags, ["Client"]);
 
   fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/src/tests/property_loader.test.ts
+++ b/src/tests/property_loader.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  buildInstancesFromSourcemap,
+  applySourcemapProperties,
+  loadSourcemapPropertyIndex,
+} from "../sourcemap/propertyLoader.js";
+
+function makeTempDir(prefix = "azul-test-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("buildInstancesFromSourcemap reads file contents and applySourcemapProperties merges properties", async () => {
+  const tmp = makeTempDir();
+  const scriptFile = path.join(tmp, "script.luau");
+  fs.writeFileSync(scriptFile, "print('smap')", "utf8");
+
+  const sourcemap = {
+    name: "Game",
+    className: "DataModel",
+    children: [
+      {
+        name: "ReplicatedStorage",
+        className: "ReplicatedStorage",
+        children: [
+          {
+            name: "ModuleA",
+            className: "Folder",
+            children: [
+              {
+                name: "Foo",
+                className: "ModuleScript",
+                guid: "g1",
+                filePaths: [scriptFile],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const smPath = path.join(tmp, "sourcemap.json");
+  fs.writeFileSync(smPath, JSON.stringify(sourcemap, null, 2), "utf8");
+
+  const instances = buildInstancesFromSourcemap(smPath);
+  assert.ok(instances && instances.length > 0, "instances built");
+  const foo = instances!.find((i) => i.name === "Foo");
+  assert.ok(foo?.source?.includes("smap"));
+
+  // Add properties to instance and pack
+  foo!.properties = { MyProp: 123 };
+  const index = loadSourcemapPropertyIndex(smPath);
+  const applied = applySourcemapProperties(instances!, index);
+  assert.strictEqual(typeof applied, "number");
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/src/tests/rojo.test.ts
+++ b/src/tests/rojo.test.ts
@@ -1,0 +1,382 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { RojoSnapshotBuilder } from "../snapshot/rojo/index.js";
+
+function makeTempDir(prefix = "azul-test-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("RojoSnapshotBuilder builds instances from default.project.json and files", async () => {
+  const tmp = makeTempDir();
+  const modules = path.join(tmp, "Modules");
+  fs.mkdirSync(modules, { recursive: true });
+  const file = path.join(modules, "Foo.server.lua");
+  fs.writeFileSync(file, "print('from rojo')", "utf8");
+
+  const project = {
+    name: "TestProj",
+    tree: {
+      $className: "DataModel",
+      ReplicatedStorage: {
+        Modules: {
+          Foo: { $path: "Modules/Foo.server.lua" },
+        },
+      },
+    },
+  };
+
+  fs.writeFileSync(
+    path.join(tmp, "default.project.json"),
+    JSON.stringify(project, null, 2),
+    "utf8",
+  );
+
+  const builder = new RojoSnapshotBuilder({
+    cwd: tmp,
+    projectFile: "default.project.json",
+  });
+  const instances = await builder.build();
+
+  const script = instances.find(
+    (i) => i.path.join("/") === "ReplicatedStorage/Modules/Foo",
+  );
+  assert.ok(script, "rojo script present");
+  assert.strictEqual(script?.className, "Script");
+  assert.strictEqual(script?.source?.includes("from rojo"), true);
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test("RojoSnapshotBuilder handles init.luau in a folder as an init script", async () => {
+  const tmp = makeTempDir();
+  const dir = path.join(tmp, "modules", "MyModule");
+  fs.mkdirSync(dir, { recursive: true });
+  const initFile = path.join(dir, "init.luau");
+  fs.writeFileSync(initFile, "print('init module')", "utf8");
+
+  const project = {
+    name: "InitProj",
+    tree: {
+      $className: "DataModel",
+      ReplicatedStorage: {
+        Modules: {
+          MyModule: { $path: "modules/MyModule" },
+        },
+      },
+    },
+  };
+
+  fs.writeFileSync(
+    path.join(tmp, "default.project.json"),
+    JSON.stringify(project, null, 2),
+    "utf8",
+  );
+
+  const builder = new RojoSnapshotBuilder({
+    cwd: tmp,
+    projectFile: "default.project.json",
+  });
+  const instances = await builder.build();
+
+  const inst = instances.find(
+    (i) => i.path.join("/") === "ReplicatedStorage/Modules/MyModule",
+  );
+  assert.ok(inst, "init-based instance emitted");
+  assert.strictEqual(inst?.className, "ModuleScript");
+  assert.strictEqual(typeof inst?.source, "string");
+  assert.ok(inst?.source?.includes("init module"));
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+test("RojoSnapshotBuilder parses complex .model.json and converts properties", async () => {
+  const tmp = makeTempDir();
+  const models = path.join(tmp, "models");
+  fs.mkdirSync(models, { recursive: true });
+
+  const modelJson = `
+{
+  "Name": "TestSuite",
+  "ClassName": "Model",
+  "Children": [
+    {
+      "Name": "TestPart",
+      "ClassName": "Part",
+      "Properties": {
+        "Size": { "Type": "Vector3", "Value": [4, 2, 1] },
+        "Position": { "Type": "Vector3", "Value": [10, 5, 0] },
+        "CFrame": { "Type": "CFrame", "Value": [10, 5, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1] },
+        "Color": { "Type": "Color3", "Value": [1, 0, 0] },
+        "BrickColor": { "Type": "BrickColor", "Value": 1001 },
+        "Shape": { "Type": "Enum", "Value": { "enumType": "PartType", "value": "Block" } },
+        "Material": { "Type": "Enum", "Value": { "enumType": "Material", "value": "Plastic" } },
+        "Anchored": true,
+        "CanCollide": false,
+        "Transparency": 0.25,
+        "Reflectance": 0.1,
+        "CustomPhysicalProperties": true,
+        "CustomPhysicalProperties": {
+          "Type": "PhysicalProperties",
+          "Value": { "Density": 0.7, "Friction": 0.5, "Elasticity": 0.3, "FrictionWeight": 1, "ElasticityWeight": 1 }
+        }
+      }
+    },
+    {
+      "Name": "TestAttachment",
+      "ClassName": "Attachment",
+      "Properties": {
+        "CFrame": { "Type": "CFrame", "Value": [1, 2, 3, 0, 1, 0, -1, 0, 0, 0, 0, 1] },
+        "Position": { "Type": "Vector3", "Value": [0.5, 1.5, 0] },
+        "Axis": { "Type": "Vector3", "Value": [0, 1, 0] },
+        "Visible": true
+      }
+    },
+    {
+      "Name": "TestLabel",
+      "ClassName": "TextLabel",
+      "Properties": {
+        "Text": "Hello World",
+        "FontFace": { "Type": "Font", "Value": { "family": "rbxasset://fonts/families/RobotoMono.json", "weight": "Thin", "style": "Normal" } },
+        "TextColor3": { "Type": "Color3", "Value": [1, 1, 1] },
+        "TextSize": 14,
+        "RichText": true,
+        "TextScaled": false,
+        "TextWrapped": true,
+        "Position": { "Type": "UDim2", "Value": [0, 10, 0, 20] },
+        "Size": { "Type": "UDim2", "Value": [1, -20, 0, 30] },
+        "BackgroundColor3": { "Type": "Color3", "Value": [0.2, 0.2, 0.2] },
+        "BackgroundTransparency": 0.5,
+        "ZIndex": 2,
+        "LayoutOrder": 1,
+        "AutoButtonColor": false
+      }
+    },
+    {
+      "Name": "TestParticles",
+      "ClassName": "ParticleEmitter",
+      "Properties": {
+        "SpreadAngle": { "Type": "Vector2", "Value": [15, 30] },
+        "Speed": { "Type": "NumberRange", "Value": [5, 10] },
+        "Lifetime": { "Type": "NumberRange", "Value": [2, 4] },
+        "Rate": 10,
+        "Color": { "Type": "ColorSequence", "Value": [[0, 1, 0, 0], [1, 1, 1, 1]] },
+        "Transparency": { "Type": "NumberSequence", "Value": [[0, 1], [1, 0]] },
+        "Enabled": true,
+        "LightEmission": 0.5,
+        "LightInfluence": 0
+      }
+    },
+    {
+      "Name": "TestBeam",
+      "ClassName": "Beam",
+      "Properties": {
+        "Color": { "Type": "ColorSequence", "Value": { "keypoints": [{ "time": 0, "value": [1, 0, 0] }, { "time": 1, "value": [0, 0, 1] }] } },
+        "Transparency": { "Type": "NumberSequence", "Value": { "keypoints": [{ "time": 0, "value": 1, "envelope": 0 }, { "time": 1, "value": 0, "envelope": 0 }] } },
+        "Width0": 0.5,
+        "Width1": 1,
+        "CurveSize0": 0,
+        "CurveSize1": 0,
+        "FaceCamera": true
+      }
+    },
+    {
+      "Name": "TestVectors",
+      "ClassName": "Model",
+      "Children": [
+        {
+          "Name": "Vec3Value",
+          "ClassName": "Vector3Value",
+          "Properties": {
+            "Value": { "Type": "Vector3", "Value": [1, 2, 3] }
+          }
+        },
+        {
+          "Name": "ColorVal",
+          "ClassName": "Color3Value",
+          "Properties": {
+            "Value": { "Type": "Color3", "Value": [0.5, 0.5, 0.5] }
+          }
+        }
+      ]
+    },
+    {
+      "Name": "TestValues",
+      "ClassName": "Model",
+      "Children": [
+        {
+          "Name": "NumVal",
+          "ClassName": "NumberValue",
+          "Properties": { "Value": 42.5 }
+        },
+        {
+          "Name": "IntVal",
+          "ClassName": "IntValue",
+          "Properties": { "Value": { "Type": "Int32", "Value": 999 } }
+        },
+        {
+          "Name": "BoolVal",
+          "ClassName": "BoolValue",
+          "Properties": { "Value": { "Type": "Bool", "Value": true } }
+        },
+        {
+          "Name": "StrVal",
+          "ClassName": "StringValue",
+          "Properties": { "Value": { "Type": "String", "Value": "test string" } }
+        }
+      ]
+    },
+    {
+      "Name": "SoundEffect",
+      "ClassName": "Sound",
+      "Properties": {
+        "SoundId": { "Type": "ContentId", "Value": "rbxassetid://123456789" },
+        "Volume": 0.8,
+        "PlaybackSpeed": 1.5,
+        "Looped": true,
+        "RollOffMode": { "Type": "Enum", "Value": { "enumType": "RollOffMode", "value": "Inverse" } },
+        "RollOffMinDistance": 10,
+        "RollOffMaxDistance": 200
+      }
+    },
+    {
+      "Name": "TestScript",
+      "ClassName": "Script",
+      "Properties": {
+        "Enabled": false,
+        "RunContext": { "Type": "Enum", "Value": { "enumType": "RunContext", "value": "Legacy" } }
+      }
+    },
+    {
+      "Name": "TestTags",
+      "ClassName": "Folder",
+      "Tags": ["red", "blue", "green"]
+    },
+    {
+      "Name": "ImplicitInference",
+      "ClassName": "Model",
+      "Properties": {},
+      "Children": [
+        {
+          "Name": "ImplicitPart",
+          "ClassName": "Part",
+          "Properties": {
+            "CFrame": [0, 10, 20, 1, 0, 0, 0, 1, 0, 0, 0, 1],
+            "Size": [2, 2, 2],
+            "Position": [5, 0, 5],
+            "Color": [0, 1, 0],
+            "Anchored": true,
+            "Transparency": 0.5
+          }
+        },
+        {
+          "Name": "ImplicitLabel",
+          "ClassName": "TextLabel",
+          "Properties": {
+            "Position": [0, 50, 0, 100],
+            "Size": [0.5, 0, 0.5, 0],
+            "Text": "Implicit",
+            "TextColor3": [1, 1, 1],
+            "BackgroundColor3": [0.1, 0.1, 0.1],
+            "BackgroundTransparency": 0.3
+          }
+        },
+        {
+          "Name": "ImplicitEmitter",
+          "ClassName": "ParticleEmitter",
+          "Properties": {
+            "SpreadAngle": [45, 60],
+            "Color": [[0, 1, 0, 0, 0], [1, 1, 1, 1, 0]],
+            "Transparency": [[0, 1], [1, 0]],
+            "Speed": [5, 10],
+            "Rate": 20
+          }
+        }
+      ]
+    },
+    {
+      "Name": "InstanceAttributes",
+      "ClassName": "Part",
+      "Attributes": {
+        "Speed": 10,
+        "DisplayName": "Runner",
+        "IsActive": true,
+        "SpawnPos": { "Type": "Vector3", "Value": [1, 2, 3] }
+      },
+      "Properties": {
+        "Anchored": true,
+        "Position": [0, 10, 0],
+        "Color": [0, 0, 1]
+      },
+      "Tags": ["important", "test"]
+    }
+  ]
+}
+`;
+
+  fs.writeFileSync(path.join(models, "test.model.json"), modelJson, "utf8");
+
+  const project = {
+    name: "ModelProj",
+    tree: {
+      $className: "DataModel",
+      ReplicatedStorage: {
+        Models: {
+          TestSuite: { $path: "models/test.model.json" },
+        },
+      },
+    },
+  };
+
+  fs.writeFileSync(
+    path.join(tmp, "default.project.json"),
+    JSON.stringify(project, null, 2),
+    "utf8",
+  );
+
+  const builder = new RojoSnapshotBuilder({
+    cwd: tmp,
+    projectFile: "default.project.json",
+  });
+  const instances = await builder.build();
+
+  const part = instances.find((i) => i.name === "TestPart");
+  assert.ok(part, "TestPart emitted");
+  assert.strictEqual(part?.className, "Part");
+  assert.ok(
+    part?.properties &&
+      (part.properties as any).Size &&
+      (part.properties as any).Size.__type === "Vector3",
+  );
+  assert.strictEqual(part?.properties?.Anchored, true);
+
+  const label = instances.find((i) => i.name === "TestLabel");
+  assert.ok(label, "TestLabel emitted");
+  assert.strictEqual(label?.properties?.Text, "Hello World");
+  assert.ok(
+    label?.properties &&
+      (label.properties as any).FontFace &&
+      (label.properties as any).FontFace.__type === "Font",
+  );
+
+  const particles = instances.find((i) => i.name === "TestParticles");
+  assert.ok(particles, "TestParticles emitted");
+  assert.ok(
+    particles?.properties &&
+      (particles.properties as any).Color &&
+      (particles.properties as any).Color.__type === "ColorSequence",
+  );
+
+  const implicit = instances.find((i) => i.name === "ImplicitPart");
+  assert.ok(implicit, "ImplicitPart emitted");
+  assert.ok(
+    implicit?.properties &&
+      (implicit.properties as any).CFrame &&
+      (implicit.properties as any).CFrame.__type === "CFrame",
+  );
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/src/tests/snapshot.test.ts
+++ b/src/tests/snapshot.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { SnapshotBuilder } from "../snapshot.js";
+
+function makeTempDir(prefix = "azul-test-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("SnapshotBuilder creates folders and script instances correctly", async () => {
+  const tmp = makeTempDir();
+  const src = path.join(tmp, "src");
+  fs.mkdirSync(path.join(src, "ReplicatedStorage", "Modules"), {
+    recursive: true,
+  });
+  const scriptPath = path.join(
+    src,
+    "ReplicatedStorage",
+    "Modules",
+    "Foo.server.lua",
+  );
+  fs.writeFileSync(scriptPath, "print('hello')", "utf8");
+
+  const builder = new SnapshotBuilder({ sourceDir: src });
+  const instances = await builder.build();
+
+  const folderPaths = instances
+    .filter((i) => i.className === "Folder")
+    .map((i) => i.path.join("/"));
+  assert.ok(folderPaths.includes("ReplicatedStorage"));
+  assert.ok(folderPaths.includes("ReplicatedStorage/Modules"));
+
+  const script = instances.find((i) => i.name === "Foo");
+  assert.ok(script, "script instance present");
+  assert.strictEqual(script?.className, "Script");
+  assert.strictEqual(script?.path.join("/"), "ReplicatedStorage/Modules/Foo");
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/src/util/scriptFile.ts
+++ b/src/util/scriptFile.ts
@@ -23,6 +23,11 @@ export function isScriptFileName(fileName: string): boolean {
   return fileName.endsWith(".lua") || fileName.endsWith(".luau");
 }
 
+export function isInstanceJsonName(fileName: string): boolean {
+  return fileName.endsWith(".model.json") 
+  // || fileName.endsWith(".meta.json"); // No support for this yet
+}
+
 export function normalizeLuaLikeFileName(fileName: string): string {
   return fileName.replace(/\.lua$/i, ".luau");
 }


### PR DESCRIPTION
## Daemon
* Rojo Compatibility: 
  * Add support for `*.model.json` instances (#44)
  * Fix "DataModel" being mistakingly spelled "Datamodel", which caused Azul to refuse to build some Rojo projects
* Add unit tests for the repository

## Plugin
* Add auto-connect option (#42)
  * This option runs in the background & keeps attempting to re-connect to the Daemon. This should help mitigate the manual friction of clicking "Connect" every time you want to perform an action.
* Migrate usage of `script.Source` to the new `ScriptEditorService` API. (https://github.com/Ransomwave/azul/pull/47)
  * This change finally allows Azul to behave nicely with Roblox Drafts, whereas before it was unable to see/edit them.