### PR TITLE
Replace deprecated Instance.Source with ScriptEditorService API

### DIFF
--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -192,7 +192,7 @@ function AzulService.instanceToData(
 		parentGuid = parentGuid,
 	}
 
-	if AzulService.isScript(instance) then data.source = (instance :: Script).Source end
+	if AzulService.isScript(instance) then data.source = ScriptEditorService:GetEditorSource(instance) end
 
 	if options and options.includeProperties then
 		local properties = Serializer.collectSerializedProperties(instance, {

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -12,6 +12,7 @@ SyncSession.__index = SyncSession
 -- Services
 local HttpService = game:GetService("HttpService")
 local RunService = game:GetService("RunService")
+local ScriptEditorService = game:GetService("ScriptEditorService")
 
 -- Modules
 local AzulService = require("./AzulService")
@@ -332,12 +333,13 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 		local path = AzulService.getInstancePath(changedScript)
 		if not path then return end
+		local source = ScriptEditorService:GetEditorSource(changedScript)
 
 		queueScriptChange({
 			guid = guid,
 			path = path,
 			className = changedScript.ClassName,
-			source = changedScript.Source,
+			source = source,
 		})
 	end
 
@@ -354,13 +356,6 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			sendInstanceUpdateDedup(instance)
 		end)
 		table.insert(self.connections, parentConnection)
-
-		if AzulService.isScript(instance) then
-			local sourceConnection = (instance :: Script):GetPropertyChangedSignal("Source"):Connect(function()
-				if self.syncEnabled then onScriptChanged(instance :: Script) end
-			end)
-			table.insert(self.connections, sourceConnection)
-		end
 	end
 
 	local function wipeChildren(container: Instance)
@@ -834,6 +829,18 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			if self.syncEnabled then onInstanceRemoved(instance) end
 		end)
 		table.insert(self.connections, descendantRemovingConnection)
+
+		-- Roblox doesn't have a script specific event for source changes, so we have to use their global signal.
+		local textDocumentChangedConnection = ScriptEditorService.TextDocumentDidChange:Connect(function(scriptDocument, _)
+			if not self.syncEnabled then return end
+
+			local changedScript = scriptDocument:GetScript()
+			if not changedScript then return end
+			if not self.trackedInstances[changedScript] then return end
+
+			onScriptChanged(changedScript :: Script)
+		end)
+		table.insert(self.connections, textDocumentChangedConnection)
 
 		local heartbeatConnection = RunService.Heartbeat:Connect(function(dt)
 			if self.syncEnabled then

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -356,6 +356,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			sendInstanceUpdateDedup(instance)
 		end)
 		table.insert(self.connections, parentConnection)
+
+		if AzulService.isScript(instance) then
+			local sourceConnection = instance:GetPropertyChangedSignal("Source"):Connect(function()
+				if not self.syncEnabled then return end
+				onScriptChanged(instance :: Script)
+			end)
+			table.insert(self.connections, sourceConnection)
+		end
 	end
 
 	local function wipeChildren(container: Instance)


### PR DESCRIPTION
If you have **Drafts mode** enabled in Studio, the plugin doesn't recognize any changes you made to a script unless you *commit* the draft. Until you commit the draft the `Script.Source` property doesn't reflect what you're actually typing in the editor, so edits are missed during a sync session.

## Fix
The fix is switching all `Script.Source` references over to `ScriptEditorService`. Looking at Roblox's documentation, Roblox recommends you use `ScriptEditorService` for reading realtime source code.

From the Roblox documentation for `ScriptEditorService:GetEditorSource`:
> Returns the edit-time source for the given script.
>
> If the script is open in the Script Editor, this method returns the text currently being displayed in the editor. If the script is not open in the editor, the method returns the text that the editor would display if it's opened. The edit-time source is not always be consistent with the Script.Source property.

Reference: https://create.roblox.com/docs/reference/engine/classes/ScriptEditorService#GetEditorSource

## Changes
- Read script source by using `ScriptEditorService:GetEditorSource()` instead of `Script.Source`.
- Detect edits through a single `ScriptEditorService.TextDocumentDidChange` connection instead of a per instance `Source` property changed signal, so live editor changes (including uncommitted drafts) are picked up.