### PR TITLE
Daemon 1.7.0 & Plugin v45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azul-sync",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azul-sync",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azul-sync",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Azul is an easy but powerful Studio-first, two-way synchronization tool for Roblox development. Edit your Roblox projects using your favorite IDE, while keeping everything in sync with Roblox Studio in real-time.",
   "main": "dist/index.js",
   "type": "module",

--- a/plugin/sourcemap.json
+++ b/plugin/sourcemap.json
@@ -5,22 +5,22 @@
     {
       "name": "ReplicatedFirst",
       "className": "ReplicatedFirst",
-      "guid": "7612",
+      "guid": "8772",
       "children": [
         {
           "name": "AzulCompanionPlugin",
           "className": "Folder",
-          "guid": "10020",
+          "guid": "11579",
           "children": [
             {
               "name": "App",
               "className": "Folder",
-              "guid": "10032",
+              "guid": "11591",
               "children": [
                 {
                   "name": "Assets",
                   "className": "ModuleScript",
-                  "guid": "10337",
+                  "guid": "12079",
                   "filePaths": [
                     "sync/ReplicatedFirst/AzulCompanionPlugin/App/Assets.luau"
                   ]
@@ -28,12 +28,12 @@
                 {
                   "name": "Components",
                   "className": "Folder",
-                  "guid": "10033",
+                  "guid": "11592",
                   "children": [
                     {
                       "name": "Border",
                       "className": "ModuleScript",
-                      "guid": "10348",
+                      "guid": "12067",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Border.luau"
                       ]
@@ -41,7 +41,7 @@
                     {
                       "name": "Box",
                       "className": "ModuleScript",
-                      "guid": "10349",
+                      "guid": "12065",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Box.luau"
                       ]
@@ -49,7 +49,7 @@
                     {
                       "name": "Checkbox",
                       "className": "ModuleScript",
-                      "guid": "10346",
+                      "guid": "12066",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Checkbox.luau"
                       ]
@@ -57,7 +57,7 @@
                     {
                       "name": "Collapsible",
                       "className": "ModuleScript",
-                      "guid": "10347",
+                      "guid": "12064",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Collapsible.luau"
                       ]
@@ -65,7 +65,7 @@
                     {
                       "name": "Container",
                       "className": "ModuleScript",
-                      "guid": "10345",
+                      "guid": "12052",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Container.luau"
                       ]
@@ -73,7 +73,7 @@
                     {
                       "name": "Corner",
                       "className": "ModuleScript",
-                      "guid": "10340",
+                      "guid": "12069",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Corner.luau"
                       ]
@@ -81,7 +81,7 @@
                     {
                       "name": "Dropdown",
                       "className": "ModuleScript",
-                      "guid": "10339",
+                      "guid": "12062",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Dropdown.luau"
                       ]
@@ -89,7 +89,7 @@
                     {
                       "name": "IconButton",
                       "className": "ModuleScript",
-                      "guid": "10341",
+                      "guid": "12063",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/IconButton.luau"
                       ]
@@ -97,7 +97,7 @@
                     {
                       "name": "Image",
                       "className": "ModuleScript",
-                      "guid": "10343",
+                      "guid": "12068",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Image.luau"
                       ]
@@ -105,7 +105,7 @@
                     {
                       "name": "Input",
                       "className": "ModuleScript",
-                      "guid": "10342",
+                      "guid": "12072",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Input.luau"
                       ]
@@ -113,7 +113,7 @@
                     {
                       "name": "List",
                       "className": "ModuleScript",
-                      "guid": "10344",
+                      "guid": "12050",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/List.luau"
                       ]
@@ -121,7 +121,7 @@
                     {
                       "name": "OptionSelector",
                       "className": "ModuleScript",
-                      "guid": "10350",
+                      "guid": "12078",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/OptionSelector.luau"
                       ]
@@ -129,7 +129,7 @@
                     {
                       "name": "Padding",
                       "className": "ModuleScript",
-                      "guid": "10354",
+                      "guid": "12077",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Padding.luau"
                       ]
@@ -137,12 +137,12 @@
                     {
                       "name": "Plugin",
                       "className": "Folder",
-                      "guid": "10034",
+                      "guid": "11594",
                       "children": [
                         {
                           "name": "Toolbar",
                           "className": "ModuleScript",
-                          "guid": "10353",
+                          "guid": "12075",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Plugin/Toolbar.luau"
                           ]
@@ -150,7 +150,7 @@
                         {
                           "name": "ToolbarButton",
                           "className": "ModuleScript",
-                          "guid": "10352",
+                          "guid": "12073",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Plugin/ToolbarButton.luau"
                           ]
@@ -158,7 +158,7 @@
                         {
                           "name": "Widget",
                           "className": "ModuleScript",
-                          "guid": "10351",
+                          "guid": "12074",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Plugin/Widget.luau"
                           ]
@@ -168,7 +168,7 @@
                     {
                       "name": "ScrollingContainer",
                       "className": "ModuleScript",
-                      "guid": "10356",
+                      "guid": "12076",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/ScrollingContainer.luau"
                       ]
@@ -176,7 +176,7 @@
                     {
                       "name": "Spinner",
                       "className": "ModuleScript",
-                      "guid": "10366",
+                      "guid": "12071",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Spinner.luau"
                       ]
@@ -184,7 +184,7 @@
                     {
                       "name": "Text",
                       "className": "ModuleScript",
-                      "guid": "10367",
+                      "guid": "12070",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Text.luau"
                       ]
@@ -192,7 +192,7 @@
                     {
                       "name": "TextButton",
                       "className": "ModuleScript",
-                      "guid": "10355",
+                      "guid": "12051",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/TextButton.luau"
                       ]
@@ -200,12 +200,12 @@
                     {
                       "name": "Util",
                       "className": "Folder",
-                      "guid": "10035",
+                      "guid": "11593",
                       "children": [
                         {
                           "name": "animate",
                           "className": "ModuleScript",
-                          "guid": "10357",
+                          "guid": "12059",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/animate.luau"
                           ]
@@ -213,7 +213,7 @@
                         {
                           "name": "default",
                           "className": "ModuleScript",
-                          "guid": "10358",
+                          "guid": "12060",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/default.luau"
                           ]
@@ -221,7 +221,7 @@
                         {
                           "name": "filterHost",
                           "className": "ModuleScript",
-                          "guid": "10359",
+                          "guid": "12061",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/filterHost.luau"
                           ]
@@ -229,7 +229,7 @@
                         {
                           "name": "filterNumber",
                           "className": "ModuleScript",
-                          "guid": "10362",
+                          "guid": "12058",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/filterNumber.luau"
                           ]
@@ -237,7 +237,7 @@
                         {
                           "name": "filterPort",
                           "className": "ModuleScript",
-                          "guid": "10360",
+                          "guid": "12056",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/filterPort.luau"
                           ]
@@ -245,7 +245,7 @@
                         {
                           "name": "getState",
                           "className": "ModuleScript",
-                          "guid": "10364",
+                          "guid": "12054",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/getState.luau"
                           ]
@@ -253,7 +253,7 @@
                         {
                           "name": "getTextSize",
                           "className": "ModuleScript",
-                          "guid": "10365",
+                          "guid": "12053",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/getTextSize.luau"
                           ]
@@ -261,7 +261,7 @@
                         {
                           "name": "isState",
                           "className": "ModuleScript",
-                          "guid": "10363",
+                          "guid": "12055",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/isState.luau"
                           ]
@@ -269,7 +269,7 @@
                         {
                           "name": "stripProps",
                           "className": "ModuleScript",
-                          "guid": "10361",
+                          "guid": "12057",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/App/Components/Util/stripProps.luau"
                           ]
@@ -281,7 +281,7 @@
                 {
                   "name": "Theme",
                   "className": "ModuleScript",
-                  "guid": "10338",
+                  "guid": "12048",
                   "filePaths": [
                     "sync/ReplicatedFirst/AzulCompanionPlugin/App/Theme.luau"
                   ]
@@ -289,7 +289,7 @@
                 {
                   "name": "UI",
                   "className": "ModuleScript",
-                  "guid": "10368",
+                  "guid": "12049",
                   "filePaths": [
                     "sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau"
                   ]
@@ -299,7 +299,7 @@
             {
               "name": "AzulService",
               "className": "ModuleScript",
-              "guid": "10369",
+              "guid": "12047",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau"
               ]
@@ -307,7 +307,7 @@
             {
               "name": "AzulSync",
               "className": "Script",
-              "guid": "12836",
+              "guid": "14849",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/AzulSync.server.luau"
               ],
@@ -322,7 +322,7 @@
             {
               "name": "Config",
               "className": "ModuleScript",
-              "guid": "10334",
+              "guid": "12080",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau"
               ]
@@ -330,30 +330,38 @@
             {
               "name": "Enums",
               "className": "ModuleScript",
-              "guid": "10335",
+              "guid": "12046",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/Enums.luau"
               ]
             },
             {
+              "name": "Logger",
+              "className": "ModuleScript",
+              "guid": "467498",
+              "filePaths": [
+                "sync/ReplicatedFirst/AzulCompanionPlugin/Logger.luau"
+              ]
+            },
+            {
               "name": "Packages",
               "className": "Folder",
-              "guid": "10023",
+              "guid": "11582",
               "children": [
                 {
                   "name": "_Index",
                   "className": "Folder",
-                  "guid": "10024",
+                  "guid": "11583",
                   "children": [
                     {
                       "name": "dervexhero_fusion-03-dev@0.3.0-dev.1",
                       "className": "Folder",
-                      "guid": "10025",
+                      "guid": "11584",
                       "children": [
                         {
                           "name": "fusion-03-dev",
                           "className": "ModuleScript",
-                          "guid": "10283",
+                          "guid": "11994",
                           "filePaths": [
                             "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev.luau"
                           ],
@@ -361,12 +369,12 @@
                             {
                               "name": "Animation",
                               "className": "Folder",
-                              "guid": "10027",
+                              "guid": "11590",
                               "children": [
                                 {
                                   "name": "getTweenRatio",
                                   "className": "ModuleScript",
-                                  "guid": "10289",
+                                  "guid": "12043",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/getTweenRatio.luau"
                                   ]
@@ -374,7 +382,7 @@
                                 {
                                   "name": "lerpType",
                                   "className": "ModuleScript",
-                                  "guid": "10288",
+                                  "guid": "12041",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/lerpType.luau"
                                   ]
@@ -382,7 +390,7 @@
                                 {
                                   "name": "packType",
                                   "className": "ModuleScript",
-                                  "guid": "10291",
+                                  "guid": "12042",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/packType.luau"
                                   ]
@@ -390,7 +398,7 @@
                                 {
                                   "name": "Spring",
                                   "className": "ModuleScript",
-                                  "guid": "10293",
+                                  "guid": "12040",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/Spring.luau"
                                   ]
@@ -398,7 +406,7 @@
                                 {
                                   "name": "springCoefficients",
                                   "className": "ModuleScript",
-                                  "guid": "10292",
+                                  "guid": "12036",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/springCoefficients.luau"
                                   ]
@@ -406,7 +414,7 @@
                                 {
                                   "name": "SpringScheduler",
                                   "className": "ModuleScript",
-                                  "guid": "10295",
+                                  "guid": "12037",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/SpringScheduler.luau"
                                   ]
@@ -414,7 +422,7 @@
                                 {
                                   "name": "Tween",
                                   "className": "ModuleScript",
-                                  "guid": "10294",
+                                  "guid": "12038",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/Tween.luau"
                                   ]
@@ -422,7 +430,7 @@
                                 {
                                   "name": "TweenScheduler",
                                   "className": "ModuleScript",
-                                  "guid": "10287",
+                                  "guid": "12039",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/TweenScheduler.luau"
                                   ]
@@ -430,7 +438,7 @@
                                 {
                                   "name": "unpackType",
                                   "className": "ModuleScript",
-                                  "guid": "10290",
+                                  "guid": "12044",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Animation/unpackType.luau"
                                   ]
@@ -440,12 +448,12 @@
                             {
                               "name": "Colour",
                               "className": "Folder",
-                              "guid": "10026",
+                              "guid": "11589",
                               "children": [
                                 {
                                   "name": "Oklab",
                                   "className": "ModuleScript",
-                                  "guid": "10286",
+                                  "guid": "12035",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Colour/Oklab.luau"
                                   ]
@@ -455,7 +463,7 @@
                             {
                               "name": "External",
                               "className": "ModuleScript",
-                              "guid": "10306",
+                              "guid": "12021",
                               "filePaths": [
                                 "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/External.luau"
                               ]
@@ -463,12 +471,12 @@
                             {
                               "name": "Instances",
                               "className": "Folder",
-                              "guid": "10030",
+                              "guid": "11588",
                               "children": [
                                 {
                                   "name": "applyInstanceProps",
                                   "className": "ModuleScript",
-                                  "guid": "10315",
+                                  "guid": "12026",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/applyInstanceProps.luau"
                                   ]
@@ -476,7 +484,7 @@
                                 {
                                   "name": "Attribute",
                                   "className": "ModuleScript",
-                                  "guid": "10314",
+                                  "guid": "12033",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/Attribute.luau"
                                   ]
@@ -484,7 +492,7 @@
                                 {
                                   "name": "AttributeChange",
                                   "className": "ModuleScript",
-                                  "guid": "10313",
+                                  "guid": "12034",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/AttributeChange.luau"
                                   ]
@@ -492,7 +500,7 @@
                                 {
                                   "name": "AttributeOut",
                                   "className": "ModuleScript",
-                                  "guid": "10312",
+                                  "guid": "12031",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/AttributeOut.luau"
                                   ]
@@ -500,7 +508,7 @@
                                 {
                                   "name": "Children",
                                   "className": "ModuleScript",
-                                  "guid": "10316",
+                                  "guid": "12032",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/Children.luau"
                                   ]
@@ -508,7 +516,7 @@
                                 {
                                   "name": "Cleanup",
                                   "className": "ModuleScript",
-                                  "guid": "10318",
+                                  "guid": "12023",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/Cleanup.luau"
                                   ]
@@ -516,7 +524,7 @@
                                 {
                                   "name": "defaultProps",
                                   "className": "ModuleScript",
-                                  "guid": "10317",
+                                  "guid": "12030",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/defaultProps.luau"
                                   ]
@@ -524,7 +532,7 @@
                                 {
                                   "name": "Hydrate",
                                   "className": "ModuleScript",
-                                  "guid": "10320",
+                                  "guid": "12027",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/Hydrate.luau"
                                   ]
@@ -532,7 +540,7 @@
                                 {
                                   "name": "New",
                                   "className": "ModuleScript",
-                                  "guid": "10319",
+                                  "guid": "12028",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/New.luau"
                                   ]
@@ -540,7 +548,7 @@
                                 {
                                   "name": "OnChange",
                                   "className": "ModuleScript",
-                                  "guid": "10321",
+                                  "guid": "12029",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/OnChange.luau"
                                   ]
@@ -548,7 +556,7 @@
                                 {
                                   "name": "OnEvent",
                                   "className": "ModuleScript",
-                                  "guid": "10322",
+                                  "guid": "12024",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/OnEvent.luau"
                                   ]
@@ -556,7 +564,7 @@
                                 {
                                   "name": "Out",
                                   "className": "ModuleScript",
-                                  "guid": "10324",
+                                  "guid": "12025",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/Out.luau"
                                   ]
@@ -564,7 +572,7 @@
                                 {
                                   "name": "Ref",
                                   "className": "ModuleScript",
-                                  "guid": "10323",
+                                  "guid": "12022",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Instances/Ref.luau"
                                   ]
@@ -574,12 +582,12 @@
                             {
                               "name": "Logging",
                               "className": "Folder",
-                              "guid": "10029",
+                              "guid": "11586",
                               "children": [
                                 {
                                   "name": "logError",
                                   "className": "ModuleScript",
-                                  "guid": "10310",
+                                  "guid": "12010",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Logging/logError.luau"
                                   ]
@@ -587,7 +595,7 @@
                                 {
                                   "name": "logErrorNonFatal",
                                   "className": "ModuleScript",
-                                  "guid": "10309",
+                                  "guid": "12008",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Logging/logErrorNonFatal.luau"
                                   ]
@@ -595,7 +603,7 @@
                                 {
                                   "name": "logWarn",
                                   "className": "ModuleScript",
-                                  "guid": "10307",
+                                  "guid": "12009",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Logging/logWarn.luau"
                                   ]
@@ -603,7 +611,7 @@
                                 {
                                   "name": "messages",
                                   "className": "ModuleScript",
-                                  "guid": "10308",
+                                  "guid": "12007",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Logging/messages.luau"
                                   ]
@@ -611,7 +619,7 @@
                                 {
                                   "name": "parseError",
                                   "className": "ModuleScript",
-                                  "guid": "10311",
+                                  "guid": "12006",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Logging/parseError.luau"
                                   ]
@@ -621,7 +629,7 @@
                             {
                               "name": "PubTypes",
                               "className": "ModuleScript",
-                              "guid": "10325",
+                              "guid": "11996",
                               "filePaths": [
                                 "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/PubTypes.luau"
                               ]
@@ -629,7 +637,7 @@
                             {
                               "name": "RobloxExternal",
                               "className": "ModuleScript",
-                              "guid": "10285",
+                              "guid": "11995",
                               "filePaths": [
                                 "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/RobloxExternal.luau"
                               ]
@@ -637,12 +645,12 @@
                             {
                               "name": "State",
                               "className": "Folder",
-                              "guid": "10028",
+                              "guid": "11587",
                               "children": [
                                 {
                                   "name": "Computed",
                                   "className": "ModuleScript",
-                                  "guid": "10304",
+                                  "guid": "12014",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/Computed.luau"
                                   ]
@@ -650,7 +658,7 @@
                                 {
                                   "name": "ForKeys",
                                   "className": "ModuleScript",
-                                  "guid": "10303",
+                                  "guid": "12013",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/ForKeys.luau"
                                   ]
@@ -658,7 +666,7 @@
                                 {
                                   "name": "ForPairs",
                                   "className": "ModuleScript",
-                                  "guid": "10305",
+                                  "guid": "12011",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/ForPairs.luau"
                                   ]
@@ -666,7 +674,7 @@
                                 {
                                   "name": "ForValues",
                                   "className": "ModuleScript",
-                                  "guid": "10301",
+                                  "guid": "12012",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/ForValues.luau"
                                   ]
@@ -674,7 +682,7 @@
                                 {
                                   "name": "isState",
                                   "className": "ModuleScript",
-                                  "guid": "10302",
+                                  "guid": "12015",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/isState.luau"
                                   ]
@@ -682,7 +690,7 @@
                                 {
                                   "name": "makeUseCallback",
                                   "className": "ModuleScript",
-                                  "guid": "10300",
+                                  "guid": "12016",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/makeUseCallback.luau"
                                   ]
@@ -690,7 +698,7 @@
                                 {
                                   "name": "Observer",
                                   "className": "ModuleScript",
-                                  "guid": "10299",
+                                  "guid": "12018",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/Observer.luau"
                                   ]
@@ -698,7 +706,7 @@
                                 {
                                   "name": "peek",
                                   "className": "ModuleScript",
-                                  "guid": "10298",
+                                  "guid": "12017",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/peek.luau"
                                   ]
@@ -706,7 +714,7 @@
                                 {
                                   "name": "updateAll",
                                   "className": "ModuleScript",
-                                  "guid": "10297",
+                                  "guid": "12019",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/updateAll.luau"
                                   ]
@@ -714,7 +722,7 @@
                                 {
                                   "name": "Value",
                                   "className": "ModuleScript",
-                                  "guid": "10296",
+                                  "guid": "12020",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/State/Value.luau"
                                   ]
@@ -724,7 +732,7 @@
                             {
                               "name": "Types",
                               "className": "ModuleScript",
-                              "guid": "10284",
+                              "guid": "11997",
                               "filePaths": [
                                 "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Types.luau"
                               ]
@@ -732,12 +740,12 @@
                             {
                               "name": "Utility",
                               "className": "Folder",
-                              "guid": "10031",
+                              "guid": "11585",
                               "children": [
                                 {
                                   "name": "cleanup",
                                   "className": "ModuleScript",
-                                  "guid": "10329",
+                                  "guid": "12003",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/cleanup.luau"
                                   ]
@@ -745,7 +753,7 @@
                                 {
                                   "name": "Contextual",
                                   "className": "ModuleScript",
-                                  "guid": "10331",
+                                  "guid": "11998",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/Contextual.luau"
                                   ]
@@ -753,7 +761,7 @@
                                 {
                                   "name": "doNothing",
                                   "className": "ModuleScript",
-                                  "guid": "10330",
+                                  "guid": "12002",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/doNothing.luau"
                                   ]
@@ -761,7 +769,7 @@
                                 {
                                   "name": "isSimilar",
                                   "className": "ModuleScript",
-                                  "guid": "10333",
+                                  "guid": "11999",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/isSimilar.luau"
                                   ]
@@ -769,7 +777,7 @@
                                 {
                                   "name": "needsDestruction",
                                   "className": "ModuleScript",
-                                  "guid": "10332",
+                                  "guid": "12000",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/needsDestruction.luau"
                                   ]
@@ -777,7 +785,7 @@
                                 {
                                   "name": "None",
                                   "className": "ModuleScript",
-                                  "guid": "10327",
+                                  "guid": "12001",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/None.luau"
                                   ]
@@ -785,7 +793,7 @@
                                 {
                                   "name": "restrictRead",
                                   "className": "ModuleScript",
-                                  "guid": "10328",
+                                  "guid": "12004",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/restrictRead.luau"
                                   ]
@@ -793,7 +801,7 @@
                                 {
                                   "name": "xtypeof",
                                   "className": "ModuleScript",
-                                  "guid": "10326",
+                                  "guid": "12005",
                                   "filePaths": [
                                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/_Index/dervexhero_fusion-03-dev@0.3.0-dev.1/fusion-03-dev/Utility/xtypeof.luau"
                                   ]
@@ -809,7 +817,7 @@
                 {
                   "name": "fusion",
                   "className": "ModuleScript",
-                  "guid": "10282",
+                  "guid": "11993",
                   "filePaths": [
                     "sync/ReplicatedFirst/AzulCompanionPlugin/Packages/fusion.luau"
                   ]
@@ -819,7 +827,7 @@
             {
               "name": "Serializer",
               "className": "ModuleScript",
-              "guid": "10259",
+              "guid": "12045",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/Serializer.luau"
               ]
@@ -827,7 +835,7 @@
             {
               "name": "SettingsStore",
               "className": "ModuleScript",
-              "guid": "10258",
+              "guid": "11992",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/SettingsStore.luau"
               ]
@@ -835,17 +843,17 @@
             {
               "name": "StudioWidgets",
               "className": "Folder",
-              "guid": "10021",
+              "guid": "11580",
               "children": [
                 {
                   "name": "Components",
                   "className": "Folder",
-                  "guid": "10022",
+                  "guid": "11581",
                   "children": [
                     {
                       "name": "CollapsibleTitledSection",
                       "className": "ModuleScript",
-                      "guid": "10275",
+                      "guid": "11983",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/CollapsibleTitledSection.luau"
                       ]
@@ -853,7 +861,7 @@
                     {
                       "name": "ColorPicker",
                       "className": "ModuleScript",
-                      "guid": "10274",
+                      "guid": "11978",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/ColorPicker.luau"
                       ]
@@ -861,7 +869,7 @@
                     {
                       "name": "CustomTextButton",
                       "className": "ModuleScript",
-                      "guid": "10276",
+                      "guid": "11976",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/CustomTextButton.luau"
                       ]
@@ -869,7 +877,7 @@
                     {
                       "name": "DropdownMenu",
                       "className": "ModuleScript",
-                      "guid": "10278",
+                      "guid": "11977",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/DropdownMenu.luau"
                       ]
@@ -877,7 +885,7 @@
                     {
                       "name": "HorizontalLine",
                       "className": "ModuleScript",
-                      "guid": "10277",
+                      "guid": "11975",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/HorizontalLine.luau"
                       ]
@@ -885,7 +893,7 @@
                     {
                       "name": "ImageButtonWithText",
                       "className": "ModuleScript",
-                      "guid": "10279",
+                      "guid": "11974",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/ImageButtonWithText.luau"
                       ]
@@ -893,7 +901,7 @@
                     {
                       "name": "LabeledCheckbox",
                       "className": "ModuleScript",
-                      "guid": "10272",
+                      "guid": "11973",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledCheckbox.luau"
                       ]
@@ -901,7 +909,7 @@
                     {
                       "name": "LabeledColorInputPicker",
                       "className": "ModuleScript",
-                      "guid": "10273",
+                      "guid": "11971",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledColorInputPicker.luau"
                       ]
@@ -909,7 +917,7 @@
                     {
                       "name": "LabeledMultiChoice",
                       "className": "ModuleScript",
-                      "guid": "10271",
+                      "guid": "11972",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledMultiChoice.luau"
                       ]
@@ -917,7 +925,7 @@
                     {
                       "name": "LabeledNumberInput",
                       "className": "ModuleScript",
-                      "guid": "10270",
+                      "guid": "11979",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledNumberInput.luau"
                       ]
@@ -925,7 +933,7 @@
                     {
                       "name": "LabeledRadioButton",
                       "className": "ModuleScript",
-                      "guid": "10265",
+                      "guid": "11980",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledRadioButton.luau"
                       ]
@@ -933,7 +941,7 @@
                     {
                       "name": "LabeledSlider",
                       "className": "ModuleScript",
-                      "guid": "10267",
+                      "guid": "11984",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledSlider.luau"
                       ]
@@ -941,7 +949,7 @@
                     {
                       "name": "LabeledTextInput",
                       "className": "ModuleScript",
-                      "guid": "10269",
+                      "guid": "11981",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledTextInput.luau"
                       ]
@@ -949,7 +957,7 @@
                     {
                       "name": "LabeledToggleButton",
                       "className": "ModuleScript",
-                      "guid": "10268",
+                      "guid": "11988",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/LabeledToggleButton.luau"
                       ]
@@ -957,7 +965,7 @@
                     {
                       "name": "StatefulImageButton",
                       "className": "ModuleScript",
-                      "guid": "10264",
+                      "guid": "11986",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/StatefulImageButton.luau"
                       ]
@@ -965,7 +973,7 @@
                     {
                       "name": "VerticallyScalingListFrame",
                       "className": "ModuleScript",
-                      "guid": "10266",
+                      "guid": "11987",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/VerticallyScalingListFrame.luau"
                       ]
@@ -973,7 +981,7 @@
                     {
                       "name": "VerticalScrollingFrame",
                       "className": "ModuleScript",
-                      "guid": "10263",
+                      "guid": "11985",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/VerticalScrollingFrame.luau"
                       ]
@@ -981,7 +989,7 @@
                     {
                       "name": "VerticalSpacer",
                       "className": "ModuleScript",
-                      "guid": "10262",
+                      "guid": "11982",
                       "filePaths": [
                         "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/Components/VerticalSpacer.luau"
                       ]
@@ -991,7 +999,7 @@
                 {
                   "name": "GuiUtilities",
                   "className": "ModuleScript",
-                  "guid": "10261",
+                  "guid": "11969",
                   "filePaths": [
                     "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/GuiUtilities.luau"
                   ]
@@ -999,7 +1007,7 @@
                 {
                   "name": "RbxGui",
                   "className": "ModuleScript",
-                  "guid": "10260",
+                  "guid": "11970",
                   "filePaths": [
                     "sync/ReplicatedFirst/AzulCompanionPlugin/StudioWidgets/RbxGui.luau"
                   ]
@@ -1009,7 +1017,7 @@
             {
               "name": "SyncSession",
               "className": "ModuleScript",
-              "guid": "10336",
+              "guid": "11989",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau"
               ]
@@ -1017,7 +1025,7 @@
             {
               "name": "UI",
               "className": "ModuleScript",
-              "guid": "10280",
+              "guid": "11990",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/UI.luau"
               ]
@@ -1025,7 +1033,7 @@
             {
               "name": "WebSocketClient",
               "className": "ModuleScript",
-              "guid": "10281",
+              "guid": "11991",
               "filePaths": [
                 "sync/ReplicatedFirst/AzulCompanionPlugin/WebSocketClient.luau"
               ]
@@ -1034,13 +1042,15 @@
         }
       ],
       "properties": {
-        "Archivable": true
+        "Sandboxed": false,
+        "Archivable": true,
+        "archivable": true
       }
     }
   ],
   "_azul": {
     "packVersion": 1,
-    "packedAt": "2026-05-29T22:04:12.826Z",
+    "packedAt": "2026-07-19T18:43:01.667Z",
     "mode": "all"
   }
 }

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -1,5 +1,3 @@
-local ReplicatedFirst = game:GetService("ReplicatedFirst")
-
 --[[
 	Azul UI Module
 	Component-based dock widget UI for the companion plugin
@@ -81,7 +79,7 @@ type AzulUI = {
 	maxHandshakesRef: fusion.Value<TextBox?>,
 	maxReconnectionsRef: fusion.Value<TextBox?>,
 	reconnectionIntervalRef: fusion.Value<TextBox?>,
-	
+
 	serviceListRef: fusion.Value<TextBox?>,
 	excludedParentsRef: fusion.Value<TextBox?>,
 
@@ -94,10 +92,6 @@ type AzulUI = {
 
 UI.logo = "rbxassetid://134336592598474"
 UI.syncedLogo = "rbxassetid://103599828888609"
-
-local function infoPrint(...)
-	print(`[Azul]: `, ...)
-end
 
 local function debugPrint(...)
 	if not Config.DEBUG_MODE then return end
@@ -264,9 +258,7 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 		Name = "Azul",
 		ToolTip = "Open Azul",
 		Image = self.icon,
-		[OnEvent("Click")] = function()
-			self.isOpen:set(not peek(self.isOpen))
-		end,
+		[OnEvent("Click")] = function() self.isOpen:set(not peek(self.isOpen)) end,
 	})
 
 	local widget = Widget({
@@ -381,27 +373,32 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 									Text = tostring(Config.HEARTBEAT_INTERVAL),
 									Finished = function(text)
 										if text == "" then return end
-										validateNumberInput(text, function(value)
-											self.callbacks.onConfigChanged("HEARTBEAT_INTERVAL", value)
-										end)
+										validateNumberInput(
+											text,
+											function(value) self.callbacks.onConfigChanged("HEARTBEAT_INTERVAL", value) end
+										)
 									end,
 								}),
 								labeledInput("Batch Idle Window (seconds)", self.batchIdleRef, {
 									Text = tostring(Config.BATCH_IDLE_WINDOW),
 									Finished = function(text)
 										if text == "" then return end
-										validateNumberInput(text, function(value)
-											self.callbacks.onConfigChanged("BATCH_IDLE_WINDOW", value)
-										end)
+										validateNumberInput(
+											text,
+											function(value) self.callbacks.onConfigChanged("BATCH_IDLE_WINDOW", value) end
+										)
 									end,
 								}),
 								labeledInput("Script Change Debounce (seconds)", self.scriptDebounceRef, {
 									Text = tostring(Config.SCRIPT_CHANGE_DEBOUNCE),
 									Finished = function(text)
 										if text == "" then return end
-										validateNumberInput(text, function(value)
-											self.callbacks.onConfigChanged("SCRIPT_CHANGE_DEBOUNCE", value)
-										end)
+										validateNumberInput(
+											text,
+											function(value)
+												self.callbacks.onConfigChanged("SCRIPT_CHANGE_DEBOUNCE", value)
+											end
+										)
 									end,
 								}),
 							}),
@@ -410,9 +407,10 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 									Text = tostring(Config.MAX_HANDSHAKES),
 									Finished = function(text)
 										if text == "" then return end
-										validateNumberInput(text, function(value)
-											self.callbacks.onConfigChanged("MAX_HANDSHAKES", value)
-										end)
+										validateNumberInput(
+											text,
+											function(value) self.callbacks.onConfigChanged("MAX_HANDSHAKES", value) end
+										)
 									end,
 								}),
 								labeledInput("Maximum Reconnection Attempts", self.maxReconnectionsRef, {
@@ -420,18 +418,23 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 									Placeholder = "-1 for infinite attempts",
 									Finished = function(text)
 										if text == "" then return end
-										validateNumberInput(text, function(value)
-											self.callbacks.onConfigChanged("MAX_RECONNECTIONS", value)
-										end, true)
+										validateNumberInput(
+											text,
+											function(value) self.callbacks.onConfigChanged("MAX_RECONNECTIONS", value) end,
+											true
+										)
 									end,
 								}),
 								labeledInput("Reconnection Interval (seconds)", self.reconnectionIntervalRef, {
 									Text = tostring(Config.RECONNECTION_INTERVAL),
 									Finished = function(text)
 										if text == "" then return end
-										validateNumberInput(text, function(value)
-											self.callbacks.onConfigChanged("RECONNECTION_INTERVAL", value)
-										end)
+										validateNumberInput(
+											text,
+											function(value)
+												self.callbacks.onConfigChanged("RECONNECTION_INTERVAL", value)
+											end
+										)
 									end,
 								}),
 							}),
@@ -476,16 +479,12 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 								TextButton {
 									Text = "Reload Sourcemap",
 									Size = UDim2.new(1, 0, 0, Theme.CompSizeY.Medium),
-									Activated = function()
-										self.callbacks.onSourcemapReload()
-									end,
+									Activated = function() self.callbacks.onSourcemapReload() end,
 								},
 								TextButton {
 									Text = "Open Place Configuration",
 									Size = UDim2.new(1, 0, 0, Theme.CompSizeY.Medium),
-									Activated = function()
-										helpers.openPlaceConfig()
-									end,
+									Activated = function() helpers.openPlaceConfig() end,
 								},
 							}),
 							Text {
@@ -503,18 +502,16 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 
 	self.azulWidget = widget
 
-	plugin.Unloading:Once(Observer(self.isOpen):onChange(function()
-		self.connectButton:SetActive(peek(self.isOpen))
-	end))
+	plugin.Unloading:Once(
+		Observer(self.isOpen):onChange(function() self.connectButton:SetActive(peek(self.isOpen)) end)
+	)
 
 	self.connectButton:SetActive(peek(self.isOpen))
 
 	return self
 end
 
-function UI:GetSyncState()
-	return self.isSyncEnabled
-end
+function UI:GetSyncState() return self.isSyncEnabled end
 
 function UI:UpdateSyncState(enabled: boolean)
 	self.isSyncEnabled = enabled
@@ -523,9 +520,7 @@ function UI:UpdateSyncState(enabled: boolean)
 	if not enabled then self.handshakeComplete:set(false) end
 end
 
-function UI:UpdateHandshakeState(complete: boolean)
-	self.handshakeComplete:set(complete)
-end
+function UI:UpdateHandshakeState(complete: boolean) self.handshakeComplete:set(complete) end
 
 function UI:SetSettingsScope(scope)
 	self.settingsScope = scope
@@ -553,7 +548,6 @@ function UI:UpdateConfig()
 	local scriptDebounceInput = peek(self.scriptDebounceRef)
 	if scriptDebounceInput then scriptDebounceInput.Text = tostring(Config.SCRIPT_CHANGE_DEBOUNCE) end
 
-
 	local maxConnectionsInput = peek(self.maxHandshakesRef)
 	if maxConnectionsInput then maxConnectionsInput.Text = tostring(Config.MAX_HANDSHAKES) end
 
@@ -562,7 +556,6 @@ function UI:UpdateConfig()
 
 	local reconnectionIntervalInput = peek(self.reconnectionIntervalRef)
 	if reconnectionIntervalInput then reconnectionIntervalInput.Text = tostring(Config.RECONNECTION_INTERVAL) end
-
 
 	local serviceListInput = peek(self.serviceListRef)
 	if serviceListInput then serviceListInput.Text = table.concat(Config.SERVICE_LIST, ", ") end

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -1,6 +1,6 @@
 --!strict
 local AzulService = {}
-AzulService.VERSION = 44
+AzulService.VERSION = 45
 
 -- Services
 local ScriptEditorService = game:GetService("ScriptEditorService")

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -7,6 +7,7 @@ local ScriptEditorService = game:GetService("ScriptEditorService")
 local HttpService = game:GetService("HttpService")
 local AssetService = game:GetService("AssetService")
 local InsertService = game:GetService("InsertService")
+local LogService = game:GetService("LogService")
 
 -- Modules
 local Serializer = require("./Serializer")
@@ -17,11 +18,6 @@ local Enums = require("./Enums")
 local function debugPrint(...)
 	if Config.SILENT_MODE or not Config.DEBUG_MODE then return end
 	print(`[🐛 AzulService]:`, ...)
-end
-
-local function infoPrint(...)
-	if Config.SILENT_MODE then return end
-	print(`[AzulService]:`, ...)
 end
 
 --[=[

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/AzulService.luau
@@ -109,6 +109,11 @@ end
 function AzulService.isProtectedRobloxContainer(instance: Instance?): boolean
 	if not instance then return false end
 
+	-- Can't destroy terrain!
+	-- In the future, we may want to serialize terrain chunks and wipe them here
+	-- For now, just skip terrain entirely
+	if instance:IsA("Terrain") then return true end
+
 	-- Top-level services cannot be destroyed or reparented
 	local okService = pcall(function() return game:GetService(instance.Name) end)
 	if instance.Parent == game and okService then return true end

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Logger.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Logger.luau
@@ -1,0 +1,25 @@
+local Logger = {}
+
+local LogService = game:GetService("LogService")
+local Config = require("./Config")
+
+function Logger.info(...)
+	if Config.SILENT_MODE then return end
+
+	-- Pack the arguments into a table
+	local args = { ... }
+
+	-- Convert every item to a string
+	for i = 1, #args do
+		args[i] = tostring(args[i])
+	end
+
+	-- Combine them with spaces and print
+	local finalString = table.concat(args, " ")
+	LogService:Info(finalString)
+end
+
+-- Keep debug printing inside each script
+-- If they were to use this Logger they'd lose the context of the script that called it
+
+return Logger

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Logger.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Logger.luau
@@ -6,16 +6,16 @@ local Config = require("./Config")
 function Logger.info(...)
 	if Config.SILENT_MODE then return end
 
-	-- Pack the arguments into a table
+	local length = select("#", ...)
 	local args = { ... }
 
 	-- Convert every item to a string
-	for i = 1, #args do
+	for i = 1, length do
 		args[i] = tostring(args[i])
 	end
 
 	-- Combine them with spaces and print
-	local finalString = table.concat(args, " ")
+	local finalString = table.concat(args, " ", 1, length)
 	LogService:Info(finalString)
 end
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Serializer.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Serializer.luau
@@ -22,11 +22,6 @@ local function debugPrint(...)
 	print(`[🐛 {script}]:`, ...)
 end
 
-local function infoPrint(...)
-	if Config.SILENT_MODE then return end
-	print(`[{script}]:`, ...)
-end
-
 local FALLBACK_SERIALIZABLE_PROPERTIES = {
 	"Archivable",
 	"Enabled",

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Serializer.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Serializer.luau
@@ -13,6 +13,19 @@ local Serializer = {}
 
 local ReflectionService = game:GetService("ReflectionService")
 local CollectionService = game:GetService("CollectionService")
+local HttpService = game:GetService("HttpService")
+local Config = require("./Config")
+
+-- Logging helpers
+local function debugPrint(...)
+	if Config.SILENT_MODE or not Config.DEBUG_MODE then return end
+	print(`[🐛 {script}]:`, ...)
+end
+
+local function infoPrint(...)
+	if Config.SILENT_MODE then return end
+	print(`[{script}]:`, ...)
+end
 
 local FALLBACK_SERIALIZABLE_PROPERTIES = {
 	"Archivable",
@@ -99,7 +112,7 @@ local FALLBACK_SERIALIZABLE_PROPERTIES = {
 }
 
 local FALLBACK_SERIALIZABLE_PROPERTY_SET: { [string]: boolean } = {}
-for _, propertyName in ipairs(FALLBACK_SERIALIZABLE_PROPERTIES) do
+for _, propertyName in FALLBACK_SERIALIZABLE_PROPERTIES do
 	FALLBACK_SERIALIZABLE_PROPERTY_SET[propertyName] = true
 end
 
@@ -171,9 +184,7 @@ local function findInstanceByPath(pathSegments: { string }): Instance?
 		local nextNode: Instance? = nil
 
 		if index == 1 then
-			local ok, service = pcall(function()
-				return game:GetService(segment)
-			end)
+			local ok, service = pcall(function() return game:GetService(segment) end)
 			if ok and service then nextNode = service end
 		end
 
@@ -356,19 +367,23 @@ function Serializer.serializeValue(
 		local path: { string }? = nil
 
 		if options and options.getInstanceRefData then
-			local ok, refData = pcall(function()
-				return options.getInstanceRefData(instanceValue)
-			end)
+			local ok, refData = pcall(function() return options.getInstanceRefData(instanceValue) end)
 			if ok and type(refData) == "table" then
 				if type(refData.guid) == "string" then guid = refData.guid end
 				if type(refData.path) == "table" then path = refData.path end
 			end
+			if not ok then
+				warn(
+					"[Serializer]: getInstanceRefData failed for instance:",
+					instanceValue:GetFullName(),
+					"Error:",
+					refData
+				)
+			end
 		end
 
 		if not guid then
-			local okGuid, debugId = pcall(function()
-				return instanceValue:GetDebugId(0)
-			end)
+			local okGuid, debugId = pcall(function() return instanceValue:GetDebugId(0) end)
 			if okGuid and type(debugId) == "string" and debugId ~= "" then guid = debugId end
 		end
 
@@ -642,9 +657,7 @@ end
 local function buildSerializableProperties(): { string }
 	if not ReflectionService then return FALLBACK_SERIALIZABLE_PROPERTIES end
 
-	local classOk, classes = pcall(function()
-		return ReflectionService:GetClasses()
-	end)
+	local classOk, classes = pcall(function() return ReflectionService:GetClasses() end)
 
 	if not classOk or type(classes) ~= "table" then return FALLBACK_SERIALIZABLE_PROPERTIES end
 
@@ -654,11 +667,9 @@ local function buildSerializableProperties(): { string }
 		local className = classInfo.Name
 		if type(className) ~= "string" then continue end
 
-		local propsOk, reflectedProperties = pcall(function()
-			return ReflectionService:GetPropertiesOfClass(className, {
-				ExcludeDisplay = true,
-			})
-		end)
+		local propsOk, reflectedProperties = pcall(
+			function() return ReflectionService:GetPropertiesOfClass(className) end
+		)
 
 		if not propsOk or type(reflectedProperties) ~= "table" then continue end
 
@@ -737,9 +748,7 @@ function Serializer.getWritableSerializablePropertySetForClass(className: string
 		return fallback
 	end
 
-	local ok, reflectedProperties = pcall(function()
-		return ReflectionService:GetPropertiesOfClass(className)
-	end)
+	local ok, reflectedProperties = pcall(function() return ReflectionService:GetPropertiesOfClass(className) end)
 
 	if not ok or type(reflectedProperties) ~= "table" then
 		writablePropertiesByClass[className] = fallback
@@ -751,12 +760,18 @@ function Serializer.getWritableSerializablePropertySetForClass(className: string
 		local reflectedName = reflected.Name
 		if type(reflectedName) ~= "string" then continue end
 
-		if not serializablePropertySet[reflectedName] then continue end
-
+		local inGlobalSet = serializablePropertySet[reflectedName] == true
 		local includedByFallback = FALLBACK_SERIALIZABLE_PROPERTY_SET[reflectedName] == true
-		if reflected.Serialized ~= true and not includedByFallback then continue end
+		local hasScriptPermits = type(reflected.Permits) == "table" and next(reflected.Permits) ~= nil
 
-		filtered[reflectedName] = true
+		-- Include property if it is known-serializable from the global/fallback sets,
+		-- OR if it has script-level read/write access (non-empty Permits). The latter
+		-- covers properties like WeldConstraint.Part0/Part1 which are script-accessible
+		-- but serialized internally through hidden proxies (Part0Internal/Part1Internal)
+		-- and therefore have Serialized = false on the user-facing property.
+		if (inGlobalSet and (reflected.Serialized == true or includedByFallback)) or hasScriptPermits then
+			filtered[reflectedName] = true
+		end
 	end
 
 	if next(filtered) == nil then filtered = fallback end
@@ -810,9 +825,7 @@ local function readAndSerializeProperty(
 		getInstanceRefData: ((Instance) -> { guid: string?, path: { string }? }?)?,
 	}?
 )
-	local ok, value = pcall(function()
-		return (instance :: any)[propertyName]
-	end)
+	local ok, value = pcall(function() return (instance :: any)[propertyName] end)
 	if not ok then return nil end
 
 	return Serializer.serializeValue(value, options)
@@ -823,9 +836,7 @@ local function getDefaultSerializedPropertiesForClass(className: string): { [str
 	if cached then return cached end
 
 	local defaults = {}
-	local ok, tempInstance = pcall(function()
-		return Instance.new(className)
-	end)
+	local ok, tempInstance = pcall(function() return Instance.new(className) end)
 
 	if not ok or not tempInstance then
 		defaultSerializedPropertiesByClass[className] = defaults
@@ -856,15 +867,13 @@ function Serializer.collectSerializedProperties(
 		getInstanceRefData: ((Instance) -> { guid: string?, path: { string }? }?)?,
 	}?
 ): { [string]: any }
+	debugPrint(`Collecting serialized properties for instance: {instance:GetFullName()} of class: {instance.ClassName}`)
+
 	local properties = {}
 	local className = instance.ClassName
 	local allowedProperties = Serializer.getWritableSerializablePropertySetForClass(className)
 	local defaultProperties = getDefaultSerializedPropertiesForClass(className)
-	local serializableProperties = Serializer.getSerializableProperties()
-
-	for _, propertyName in ipairs(serializableProperties) do
-		if not allowedProperties[propertyName] then continue end
-
+	for propertyName in pairs(allowedProperties) do
 		if propertyName == "Name" or propertyName == "Parent" then continue end
 		if propertyName == "Transparency" and instance:IsA("GuiObject") then continue end
 
@@ -876,6 +885,8 @@ function Serializer.collectSerializedProperties(
 			end
 		end
 	end
+
+	debugPrint(`Collected serialized properties for instance: {instance}: {HttpService:JSONEncode(properties)}`)
 
 	return properties
 end
@@ -908,11 +919,7 @@ function Serializer.applySerializedProperties(
 			if not resolvedProperty then continue end
 
 			local deserialized = Serializer.deserializeValue(serialized, options)
-			if deserialized ~= nil then
-				pcall(function()
-					(instance :: any)[resolvedProperty] = deserialized
-				end)
-			end
+			if deserialized ~= nil then pcall(function() (instance :: any)[resolvedProperty] = deserialized end) end
 		end
 	end
 end
@@ -926,9 +933,7 @@ function Serializer.applySerializedAttributes(instance: Instance, attributes: { 
 	if type(attributes) ~= "table" then return end
 
 	for key, value in pairs(attributes) do
-		pcall(function()
-			instance:SetAttribute(key, value)
-		end)
+		pcall(function() instance:SetAttribute(key, value) end)
 	end
 end
 
@@ -941,9 +946,7 @@ end
 function Serializer.collectSerializedTags(instance: Instance): { string }
 	if not CollectionService then return {} end
 
-	local ok, tags = pcall(function()
-		return CollectionService:GetTags(instance)
-	end)
+	local ok, tags = pcall(function() return CollectionService:GetTags(instance) end)
 
 	if not ok or type(tags) ~= "table" then return {} end
 
@@ -960,9 +963,7 @@ function Serializer.applySerializedTags(instance: Instance, tags: { string }?)
 	if type(tags) ~= "table" or not CollectionService then return end
 
 	local existingTagSet: { [string]: boolean } = {}
-	local okExisting, existing = pcall(function()
-		return CollectionService:GetTags(instance)
-	end)
+	local okExisting, existing = pcall(function() return CollectionService:GetTags(instance) end)
 	if okExisting and type(existing) == "table" then
 		for _, tagName in ipairs(existing) do
 			existingTagSet[tagName] = true
@@ -973,19 +974,13 @@ function Serializer.applySerializedTags(instance: Instance, tags: { string }?)
 	for _, tagName in ipairs(tags) do
 		if type(tagName) == "string" and tagName ~= "" then
 			incomingTagSet[tagName] = true
-			if not existingTagSet[tagName] then
-				pcall(function()
-					CollectionService:AddTag(instance, tagName)
-				end)
-			end
+			if not existingTagSet[tagName] then pcall(function() CollectionService:AddTag(instance, tagName) end) end
 		end
 	end
 
 	for existingTagName in pairs(existingTagSet) do
 		if not incomingTagSet[existingTagName] then
-			pcall(function()
-				CollectionService:RemoveTag(instance, existingTagName)
-			end)
+			pcall(function() CollectionService:RemoveTag(instance, existingTagName) end)
 		end
 	end
 end

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Serializer.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Serializer.luau
@@ -762,7 +762,9 @@ function Serializer.getWritableSerializablePropertySetForClass(className: string
 
 		local inGlobalSet = serializablePropertySet[reflectedName] == true
 		local includedByFallback = FALLBACK_SERIALIZABLE_PROPERTY_SET[reflectedName] == true
-		local hasScriptPermits = type(reflected.Permits) == "table" and next(reflected.Permits) ~= nil
+		local hasScriptPermits = type(reflected.Permits) == "table"
+			and reflected.Permits.Write ~= nil
+			and reflected.Permits.Read ~= nil
 
 		-- Include property if it is known-serializable from the global/fallback sets,
 		-- OR if it has script-level read/write access (non-empty Permits). The latter

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -400,33 +400,6 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		})
 	end
 
-	local function attachListeners(instance)
-		if not shouldIncludeInSnapshot(instance) then
-			return
-		end
-
-		local nameConnnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
-			sendInstanceUpdateDedup(instance)
-		end)
-		table.insert(self.connections, nameConnnection)
-
-		local parentConnection = instance:GetPropertyChangedSignal("Parent"):Connect(function()
-			if instance.Parent == nil then
-				return
-			end
-			sendInstanceUpdateDedup(instance)
-		end)
-		table.insert(self.connections, parentConnection)
-
-		if AzulService.isScript(instance) then
-			local sourceConnection = instance:GetPropertyChangedSignal("Source"):Connect(function()
-				if not self.syncEnabled then return end
-				onScriptChanged(instance :: Script)
-			end)
-			table.insert(self.connections, sourceConnection)
-		end
-	end
-
 	local function wipeChildren(container: Instance)
 		for _, child in ipairs(container:GetChildren()) do
 			if AzulService.isProtectedRobloxContainer(child) then
@@ -495,22 +468,6 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		})
 	end
 
-	local function onInstanceAdded(instance: Instance)
-		if self.suppressOutbound then
-			return
-		end
-		if not shouldIncludeInSnapshot(instance) then
-			return
-		end
-
-		local data = AzulService.instanceToData(instance, self.trackedInstances, self.guidMap, self.usedGuids)
-		if not data then
-			return
-		end
-		sendInstanceUpdateDedup(instance)
-		attachListeners(instance)
-	end
-
 	local function onInstanceRemoved(instance)
 		if self.suppressOutbound then
 			return
@@ -532,6 +489,57 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		self.usedGuids[guid] = nil
 
 		queueDeletion(guid)
+	end
+
+	local function attachListeners(instance)
+		if not shouldIncludeInSnapshot(instance) then
+			return
+		end
+
+		local nameConnnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
+			if not shouldIncludeInSnapshot(instance) then
+				return
+			end
+			sendInstanceUpdateDedup(instance)
+		end)
+		table.insert(self.connections, nameConnnection)
+
+		local parentConnection = instance:GetPropertyChangedSignal("Parent"):Connect(function()
+			if instance.Parent == nil then
+				return
+			elseif not shouldIncludeInSnapshot(instance) then
+				onInstanceRemoved(instance)
+				return
+			end
+			sendInstanceUpdateDedup(instance)
+		end)
+		table.insert(self.connections, parentConnection)
+
+		if AzulService.isScript(instance) then
+			local sourceConnection = instance:GetPropertyChangedSignal("Source"):Connect(function()
+				if not self.syncEnabled or not shouldIncludeInSnapshot(instance) then
+					return
+				end
+				onScriptChanged(instance :: Script)
+			end)
+			table.insert(self.connections, sourceConnection)
+		end
+	end
+
+	local function onInstanceAdded(instance: Instance)
+		if self.suppressOutbound then
+			return
+		end
+		if not shouldIncludeInSnapshot(instance) then
+			return
+		end
+
+		local data = AzulService.instanceToData(instance, self.trackedInstances, self.guidMap, self.usedGuids)
+		if not data then
+			return
+		end
+		sendInstanceUpdateDedup(instance)
+		attachListeners(instance)
 	end
 
 	local function sendFullSnapshot(options: { includeProperties: boolean, scriptsAndDescendantsOnly: boolean }?)

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -922,6 +922,54 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				self:stopSync()
 				return
 			end
+
+			-- Handshake succeeded: now set up per-instance listeners.
+			-- Deferred so the handshake ack can finish processing first.
+			task.defer(function()
+				local ok, err = pcall(function()
+					local function setupListeners(parent)
+						for _, child in ipairs(parent:GetChildren()) do
+							attachListeners(child)
+							setupListeners(child)
+						end
+					end
+
+					for _, service in ipairs(game:GetChildren()) do
+						setupListeners(service)
+						task.wait()
+					end
+				end)
+				if not ok then
+					warn("[Azul]: Error during listener setup:", err)
+					self:stopSync()
+				end
+			end)
+
+			local descendantAddedConnection = game.DescendantAdded:Connect(function(instance)
+				if self.syncEnabled then
+					onInstanceAdded(instance)
+				end
+			end)
+			table.insert(self.connections, descendantAddedConnection)
+
+			local descendantRemovingConnection = game.DescendantRemoving:Connect(function(instance)
+				if self.syncEnabled then
+					onInstanceRemoved(instance)
+				end
+			end)
+			table.insert(self.connections, descendantRemovingConnection)
+
+			-- Roblox doesn't have a script-specific event for source changes, so we use the global signal.
+			local textDocumentChangedConnection = ScriptEditorService.TextDocumentDidChange:Connect(function(scriptDocument, _)
+				if not self.syncEnabled then return end
+
+				local changedScript = scriptDocument:GetScript()
+				if not changedScript then return end
+				if not self.trackedInstances[changedScript] then return end
+
+				onScriptChanged(changedScript :: Script)
+			end)
+			table.insert(self.connections, textDocumentChangedConnection)
 		end)
 
 		self.wsClient:on("message", function(message)
@@ -945,52 +993,6 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			self:stopSync()
 			return
 		end
-
-		task.defer(function()
-			local ok, err = pcall(function()
-				local function setupListeners(parent)
-					for _, child in ipairs(parent:GetChildren()) do
-						attachListeners(child)
-						setupListeners(child)
-					end
-				end
-
-				for _, service in ipairs(game:GetChildren()) do
-					setupListeners(service)
-					task.wait()
-				end
-			end)
-			if not ok then
-				warn("[Azul]: Error during listener setup:", err)
-				self:stopSync()
-			end
-		end)
-
-		local descendantAddedConnection = game.DescendantAdded:Connect(function(instance)
-			if self.syncEnabled then
-				onInstanceAdded(instance)
-			end
-		end)
-		table.insert(self.connections, descendantAddedConnection)
-
-		local descendantRemovingConnection = game.DescendantRemoving:Connect(function(instance)
-			if self.syncEnabled then
-				onInstanceRemoved(instance)
-			end
-		end)
-		table.insert(self.connections, descendantRemovingConnection)
-
-		-- Roblox doesn't have a script specific event for source changes, so we have to use their global signal.
-		local textDocumentChangedConnection = ScriptEditorService.TextDocumentDidChange:Connect(function(scriptDocument, _)
-			if not self.syncEnabled then return end
-
-			local changedScript = scriptDocument:GetScript()
-			if not changedScript then return end
-			if not self.trackedInstances[changedScript] then return end
-
-			onScriptChanged(changedScript :: Script)
-		end)
-		table.insert(self.connections, textDocumentChangedConnection)
 
 		local heartbeatConnection = RunService.Heartbeat:Connect(function(dt)
 			if self.syncEnabled then

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -49,6 +49,7 @@ export type SyncSession = {
 	batchFlushToken: number,
 	batchAccumulator: number,
 	serviceSet: { [string]: boolean },
+	listenerAttachedInstances: { [Instance]: boolean },
 	handshakeComplete: boolean,
 
 	-- Methods
@@ -129,6 +130,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	self.batchFlushToken = 0
 	self.batchAccumulator = 0
 	self.serviceSet = {}
+	self.listenerAttachedInstances = {}
 	self.handshakeComplete = false
 
 	-- Auto-connect helpers
@@ -419,6 +421,8 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 	local function attachListeners(instance)
 		if not shouldIncludeInSnapshot(instance) then return end
+		if self.listenerAttachedInstances[instance] then return end
+		self.listenerAttachedInstances[instance] = true
 
 		local nameConnnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
 			if not shouldIncludeInSnapshot(instance) then return end
@@ -905,6 +909,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		self.trackedInstances = {}
 		self.guidMap = {}
 		self.batchAccumulator = 0
+		table.clear(self.listenerAttachedInstances)
 		table.clear(self.pendingInstanceUpdates)
 		table.clear(self.pendingScriptChanges)
 		table.clear(self.pendingScriptChangeReady)

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -80,33 +80,23 @@ local PUSH_CONFIG_PATH = {
 local INITIAL_BATCH_INTERVAL = 0.2 -- Seconds between outbound batch flushes
 
 local function safeGetNumber(value: any, default: number)
-	if type(value) == "number" and value > 0 then
-		return value
-	end
+	if type(value) == "number" and value > 0 then return value end
 	return default
 end
 
 function SyncSession:debugPrint(...)
-	if self.config.SILENT_MODE or not self.config.DEBUG_MODE then
-		return
-	end
+	if self.config.SILENT_MODE or not self.config.DEBUG_MODE then return end
 	print(`[🐛 Azul::{script}]:`, ...)
 end
 
 function SyncSession:infoPrint(...)
-	if self.config.SILENT_MODE then
-		return
-	end
+	if self.config.SILENT_MODE then return end
 	print(`[Azul]: `, ...)
 end
 
-function SyncSession:rebuildServiceSet()
-	AzulService.rebuildServiceSet(self.serviceSet)
-end
+function SyncSession:rebuildServiceSet() AzulService.rebuildServiceSet(self.serviceSet) end
 
-function SyncSession:setUI(ui)
-	self.ui = ui
-end
+function SyncSession:setUI(ui) self.ui = ui end
 
 function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsStore, config: any): SyncSession
 	local self = (setmetatable({}, SyncSession) :: any) :: SyncSession
@@ -148,16 +138,12 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	self:rebuildServiceSet()
 
 	local function shouldIncludeInSnapshot(instance)
-		if not instance then
-			return false
-		end
+		if not instance then return false end
 		return not AzulService.isExcluded(instance, self.serviceSet)
 	end
 
 	local function sendMessage(messageTypeOrPayload: string | { any }, data: any?)
-		if not self.wsClient or not self.wsClient.connected then
-			return false
-		end
+		if not self.wsClient or not self.wsClient.connected then return false end
 
 		local message
 
@@ -178,9 +164,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 
 		self:debugPrint(`Sending message: {message.type}`)
-		local encodeOk, encodedOrErr = pcall(function()
-			return HttpService:JSONEncode(message)
-		end)
+		local encodeOk, encodedOrErr = pcall(function() return HttpService:JSONEncode(message) end)
 		if not encodeOk then
 			warn(`[Azul]: Cannot JSON-encode outbound message (type: {tostring(message.type)}): {encodedOrErr}`)
 			return false
@@ -229,9 +213,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		table.clear(self.pendingInstanceUpdates)
 		table.clear(self.pendingDeletes)
 
-		if #messages == 0 then
-			return
-		end
+		if #messages == 0 then return end
 
 		if self.batchingEnabled and #messages > 1 then
 			if #messages > 200 then
@@ -248,40 +230,28 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function scheduleBatchFlush()
-		if not self.batchingEnabled then
-			return
-		end
+		if not self.batchingEnabled then return end
 
 		self.batchFlushToken += 1
 		local token = self.batchFlushToken
 
 		task.delay(safeGetNumber(self.config.BATCH_IDLE_WINDOW, 0.1), function()
-			if token ~= self.batchFlushToken then
-				return
-			end
+			if token ~= self.batchFlushToken then return end
 			flushOutboundQueues()
 		end)
 	end
 
 	local function queueInstanceUpdate(data)
-		if self.suppressOutbound or not self.syncEnabled then
-			return
-		end
-		if not data or not data.guid then
-			return
-		end
+		if self.suppressOutbound or not self.syncEnabled then return end
+		if not data or not data.guid then return end
 
 		self.pendingInstanceUpdates[data.guid] = data
 		scheduleBatchFlush()
 	end
 
 	local function queueScriptChange(payload)
-		if self.suppressOutbound or not self.syncEnabled then
-			return
-		end
-		if not payload or not payload.guid then
-			return
-		end
+		if self.suppressOutbound or not self.syncEnabled then return end
+		if not payload or not payload.guid then return end
 
 		self.pendingScriptChangeReady[payload.guid] = false
 		self.pendingScriptChanges[payload.guid] = payload
@@ -290,15 +260,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		self.scriptChangeDebounceTokenByGuid[payload.guid] = token
 
 		task.delay(safeGetNumber(self.config.SCRIPT_CHANGE_DEBOUNCE, 0.35), function()
-			if not self.syncEnabled or self.suppressOutbound then
-				return
-			end
-			if self.scriptChangeDebounceTokenByGuid[payload.guid] ~= token then
-				return
-			end
-			if not self.pendingScriptChanges[payload.guid] then
-				return
-			end
+			if not self.syncEnabled or self.suppressOutbound then return end
+			if self.scriptChangeDebounceTokenByGuid[payload.guid] ~= token then return end
+			if not self.pendingScriptChanges[payload.guid] then return end
 
 			self.pendingScriptChangeReady[payload.guid] = true
 			scheduleBatchFlush()
@@ -306,12 +270,8 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function queueDeletion(guid: string)
-		if self.suppressOutbound or not self.syncEnabled then
-			return
-		end
-		if not guid or guid == "" then
-			return
-		end
+		if self.suppressOutbound or not self.syncEnabled then return end
+		if not guid or guid == "" then return end
 
 		self.pendingDeletes[guid] = true
 		scheduleBatchFlush()
@@ -329,9 +289,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function sendInstanceUpdateDedup(instance)
-		if self.suppressOutbound or not self.syncEnabled then
-			return
-		end
+		if self.suppressOutbound or not self.syncEnabled then return end
 
 		local data = AzulService.instanceToDataDedup(
 			instance,
@@ -340,9 +298,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			self.usedGuids,
 			self.lastInstanceUpdate
 		)
-		if not data then
-			return
-		end
+		if not data then return end
 
 		local guid = data.guid
 		self.trackedInstances[instance] = guid
@@ -352,19 +308,13 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function shouldSync(instance)
-		if not instance then
-			return false
-		end
-		if not AzulService.isScript(instance) then
-			return false
-		end
+		if not instance then return false end
+		if not AzulService.isScript(instance) then return false end
 		return not AzulService.isExcluded(instance, self.serviceSet)
 	end
 
 	local function onScriptChanged(changedScript: Script | LocalScript | ModuleScript)
-		if self.suppressOutbound or not shouldSync(changedScript) then
-			return
-		end
+		if self.suppressOutbound or not shouldSync(changedScript) then return end
 
 		local guid = AzulService.getOrCreateGUID(changedScript, self.trackedInstances, self.guidMap, self.usedGuids)
 
@@ -377,9 +327,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			return
 		end
 
-		if self.applyingPatch then
-			return
-		end
+		if self.applyingPatch then return end
 
 		local lastPatch = self.lastPatchTime[guid] or 0
 		local now = tick()
@@ -402,15 +350,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 	local function wipeChildren(container: Instance)
 		for _, child in ipairs(container:GetChildren()) do
-			if AzulService.isProtectedRobloxContainer(child) then
-				continue
-			end
-			local ok, err = pcall(function()
-				child:Destroy()
-			end)
-			if not ok then
-				warn(`[Azul]: Cannot destroy '{child.Name}': {err}`)
-			end
+			if AzulService.isProtectedRobloxContainer(child) then continue end
+			local ok, err = pcall(function() child:Destroy() end)
+			if not ok then warn(`[Azul]: Cannot destroy '{child.Name}': {err}`) end
 		end
 	end
 
@@ -421,18 +363,14 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			local path = item.path
 			if type(path) == "table" and #path >= 1 then
 				local rootName = path[1]
-				if type(rootName) == "string" and rootName ~= "" then
-					rootsSeen[rootName] = true
-				end
+				if type(rootName) == "string" and rootName ~= "" then rootsSeen[rootName] = true end
 			end
 		end
 
 		for rootName in pairs(rootsSeen) do
 			local rootInstance: Instance? = nil
 
-			local okService, service = pcall(function()
-				return game:GetService(rootName)
-			end)
+			local okService, service = pcall(function() return game:GetService(rootName) end)
 			if okService and service then
 				rootInstance = service
 			else
@@ -440,12 +378,8 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end
 
 			if rootInstance then
-				local ok, err = pcall(function()
-					wipeChildren(rootInstance)
-				end)
-				if not ok then
-					warn(`[Azul]: Failed to wipe children for root container '{rootName}': {err}`)
-				end
+				local ok, err = pcall(function() wipeChildren(rootInstance) end)
+				if not ok then warn(`[Azul]: Failed to wipe children for root container '{rootName}': {err}`) end
 			else
 				warn(`[Azul]: Destructive build could not find root container '{rootName}', skipping wipe`)
 			end
@@ -469,20 +403,12 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function onInstanceRemoved(instance)
-		if self.suppressOutbound then
-			return
-		end
-		if not self.trackedInstances[instance] then
-			return
-		end
+		if self.suppressOutbound then return end
+		if not self.trackedInstances[instance] then return end
 
 		local guid = self.trackedInstances[instance]
-		if not guid then
-			guid = instance:GetDebugId(0)
-		end
-		if not guid then
-			return
-		end
+		if not guid then guid = instance:GetDebugId(0) end
+		if not guid then return end
 
 		self.trackedInstances[instance] = nil
 		self.guidMap[guid] = nil
@@ -492,14 +418,10 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function attachListeners(instance)
-		if not shouldIncludeInSnapshot(instance) then
-			return
-		end
+		if not shouldIncludeInSnapshot(instance) then return end
 
 		local nameConnnection = instance:GetPropertyChangedSignal("Name"):Connect(function()
-			if not shouldIncludeInSnapshot(instance) then
-				return
-			end
+			if not shouldIncludeInSnapshot(instance) then return end
 			sendInstanceUpdateDedup(instance)
 		end)
 		table.insert(self.connections, nameConnnection)
@@ -516,10 +438,8 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		table.insert(self.connections, parentConnection)
 
 		if AzulService.isScript(instance) then
-			local sourceConnection = instance:GetPropertyChangedSignal("Source"):Connect(function()
-				if not self.syncEnabled or not shouldIncludeInSnapshot(instance) then
-					return
-				end
+			local sourceConnection = (instance :: Script):GetPropertyChangedSignal("Source"):Connect(function()
+				if not self.syncEnabled or not shouldIncludeInSnapshot(instance) then return end
 				onScriptChanged(instance :: Script)
 			end)
 			table.insert(self.connections, sourceConnection)
@@ -527,17 +447,11 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	local function onInstanceAdded(instance: Instance)
-		if self.suppressOutbound then
-			return
-		end
-		if not shouldIncludeInSnapshot(instance) then
-			return
-		end
+		if self.suppressOutbound then return end
+		if not shouldIncludeInSnapshot(instance) then return end
 
 		local data = AzulService.instanceToData(instance, self.trackedInstances, self.guidMap, self.usedGuids)
-		if not data then
-			return
-		end
+		if not data then return end
 		sendInstanceUpdateDedup(instance)
 		attachListeners(instance)
 	end
@@ -554,9 +468,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				if AzulService.isScript(descendant) and shouldIncludeInSnapshot(descendant) then
 					local current: Instance? = descendant
 					while current and current ~= game do
-						if shouldIncludeInSnapshot(current) then
-							includeAncestorsOfScripts[current] = true
-						end
+						if shouldIncludeInSnapshot(current) then includeAncestorsOfScripts[current] = true end
 						current = current.Parent
 					end
 				end
@@ -624,9 +536,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				end
 			end
 
-			if index % batchSize == 0 then
-				task.wait()
-			end
+			if index % batchSize == 0 then task.wait() end
 			index += 1
 		end
 
@@ -682,14 +592,8 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		if not self.handshakeComplete then
 			self.handshakeComplete = true
 			self:debugPrint("Handshake implicitly satisfied by daemon message")
-			if self.ui then
-				self.ui:UpdateHandshakeState(true)
-			end
-			if self._handshakeBindable then
-				pcall(function()
-					self._handshakeBindable:Fire()
-				end)
-			end
+			if self.ui then self.ui:UpdateHandshakeState(true) end
+			if self._handshakeBindable then pcall(function() self._handshakeBindable:Fire() end) end
 		end
 	end
 
@@ -736,9 +640,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			setOutboundSuppressed(true)
 
 			local ok, err = pcall(function()
-				if message.destructive == true then
-					wipeBuildRoots(message.data or {})
-				end
+				if message.destructive == true then wipeBuildRoots(message.data or {}) end
 
 				local created, updated, appliedGuidMap = AzulService.applySnapshotInstances(message.data)
 				for guid, instance in pairs(appliedGuidMap) do
@@ -750,13 +652,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end)
 
 			setOutboundSuppressed(false)
-			if not ok then
-				warn("[Azul]: Error applying build snapshot: ", err)
-			end
+			if not ok then warn("[Azul]: Error applying build snapshot: ", err) end
 
-			task.delay(0.5, function()
-				self:stopSync()
-			end)
+			task.delay(0.5, function() self:stopSync() end)
 		elseif message.type == "pushSnapshot" then
 			implicitHandshake()
 			self:infoPrint("Applying push snapshot from daemon")
@@ -777,9 +675,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 					)
 
 					local targetContainer = AzulService.getOrCreatePath(destination)
-					if mapping.destructive then
-						wipeChildren(targetContainer)
-					end
+					if mapping.destructive then wipeChildren(targetContainer) end
 
 					local created, updated, appliedGuidMap =
 						AzulService.applySnapshotInstances(mapping.instances or {}, mapping.destination)
@@ -795,13 +691,9 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end)
 
 			setOutboundSuppressed(false)
-			if not ok then
-				warn("[Azul]: Error applying push snapshot", err)
-			end
+			if not ok then warn("[Azul]: Error applying push snapshot", err) end
 
-			task.delay(0.5, function()
-				self:stopSync()
-			end)
+			task.delay(0.5, function() self:stopSync() end)
 		elseif message.type == "requestPushConfig" then
 			sendDaemonConfig(true)
 		elseif message.type == "handshakeAck" then
@@ -810,14 +702,8 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				self:debugPrint("Handshake acknowledged by daemon")
 				self:infoPrint("Handshake with Daemon successful")
 				sendDaemonConfig()
-				if self.ui then
-					self.ui:UpdateHandshakeState(true)
-				end
-				if self._handshakeBindable then
-					pcall(function()
-						self._handshakeBindable:Fire()
-					end)
-				end
+				if self.ui then self.ui:UpdateHandshakeState(true) end
+				if self._handshakeBindable then pcall(function() self._handshakeBindable:Fire() end) end
 			end
 		elseif message.type == "daemonDisconnect" then
 			self:infoPrint("Daemon is shutting down; disconnecting plugin")
@@ -853,21 +739,15 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 			local startTime = tick()
 			while tick() - startTime < HANDSHAKE_TIMEOUT do
-				if not self.syncEnabled or not self.wsClient or not self.wsClient.connected then
-					return false
-				end
-				if self.handshakeComplete then
-					return true
-				end
+				if not self.syncEnabled or not self.wsClient or not self.wsClient.connected then return false end
+				if self.handshakeComplete then return true end
 				task.wait(0.1)
 			end
 
 			tries += 1
 
 			--// Otherwise would bloat the console
-			if not self.config.AUTO_CONNECT then
-				warn(`[Azul]: Handshake attempt {tries} failed, retrying...`)
-			end
+			if not self.config.AUTO_CONNECT then warn(`[Azul]: Handshake attempt {tries} failed, retrying...`) end
 
 		--self.wsClient:reconnect()
 		until tries >= HANDSHAKE_MAX_RETRIES
@@ -875,9 +755,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		return self.handshakeComplete
 	end
 
-	function self:reloadSourcemap()
-		sendFullSnapshot()
-	end
+	function self:reloadSourcemap() sendFullSnapshot() end
 
 	function self:startSync(suppressInfo: boolean?)
 		if self.syncEnabled then
@@ -886,19 +764,13 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end
 		local suppress = suppressInfo == true
 		self._suppressAutoConnectLogs = suppress
-		if not suppress then
-			self:infoPrint("Starting sync...")
-		end
+		if not suppress then self:infoPrint("Starting sync...") end
 		self.syncEnabled = true
 		self.batchingEnabled = false
 		self.batchFlushToken += 1
 
-		if self.ui then
-			self.ui:UpdateSyncState(true)
-		end
-		if self.ui then
-			self.ui:UpdateHandshakeState(false)
-		end
+		if self.ui then self.ui:UpdateSyncState(true) end
+		if self.ui then self.ui:UpdateHandshakeState(false) end
 
 		self.wsClient = WebSocketClient.new(self.config.WS_URL, {
 			debugMode = self.config.DEBUG_MODE,
@@ -946,46 +818,38 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 			end)
 
 			local descendantAddedConnection = game.DescendantAdded:Connect(function(instance)
-				if self.syncEnabled then
-					onInstanceAdded(instance)
-				end
+				if self.syncEnabled then onInstanceAdded(instance) end
 			end)
 			table.insert(self.connections, descendantAddedConnection)
 
 			local descendantRemovingConnection = game.DescendantRemoving:Connect(function(instance)
-				if self.syncEnabled then
-					onInstanceRemoved(instance)
-				end
+				if self.syncEnabled then onInstanceRemoved(instance) end
 			end)
 			table.insert(self.connections, descendantRemovingConnection)
 
 			-- Roblox doesn't have a script-specific event for source changes, so we use the global signal.
-			local textDocumentChangedConnection = ScriptEditorService.TextDocumentDidChange:Connect(function(scriptDocument, _)
-				if not self.syncEnabled then return end
+			local textDocumentChangedConnection = ScriptEditorService.TextDocumentDidChange:Connect(
+				function(scriptDocument, _)
+					if not self.syncEnabled then return end
 
-				local changedScript = scriptDocument:GetScript()
-				if not changedScript then return end
-				if not self.trackedInstances[changedScript] then return end
+					local changedScript = scriptDocument:GetScript()
+					if not changedScript then return end
+					if not self.trackedInstances[changedScript] then return end
 
-				onScriptChanged(changedScript :: Script)
-			end)
+					onScriptChanged(changedScript :: Script)
+				end
+			)
 			table.insert(self.connections, textDocumentChangedConnection)
 		end)
 
-		self.wsClient:on("message", function(message)
-			processMessage(message)
-		end)
+		self.wsClient:on("message", function(message) processMessage(message) end)
 
 		self.wsClient:on("disconnect", function()
-			if not self._suppressAutoConnectLogs then
-				self:infoPrint("Disconnected from daemon")
-			end
+			if not self._suppressAutoConnectLogs then self:infoPrint("Disconnected from daemon") end
 			self:stopSync()
 		end)
 
-		self.wsClient:on("error", function(error)
-			warn("[Azul]: Connection error:", error)
-		end)
+		self.wsClient:on("error", function(error) warn("[Azul]: Connection error:", error) end)
 
 		local connected = self.wsClient:connect()
 		if not connected then
@@ -1019,37 +883,23 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		end)
 		table.insert(self.connections, heartbeatConnection)
 
-		if not self._suppressAutoConnectLogs then
-			self:infoPrint("Sync enabled")
-		end
+		if not self._suppressAutoConnectLogs then self:infoPrint("Sync enabled") end
 	end
 
 	function self:stopSync(dontRelayDisconnect: boolean?)
-		if not self.syncEnabled then
-			return
-		end
+		if not self.syncEnabled then return end
 
-		if not dontRelayDisconnect then
-			sendMessage("clientDisconnect", {})
-		end
+		if not dontRelayDisconnect then sendMessage("clientDisconnect", {}) end
 
 		local suppress = self._suppressAutoConnectLogs == true
-		if not suppress then
-			self:infoPrint("Stopping sync...")
-		end
+		if not suppress then self:infoPrint("Stopping sync...") end
 		self.syncEnabled = false
 		self.handshakeComplete = false
 
-		if self.ui then
-			self.ui:UpdateHandshakeState(false)
-		end
-		if self.ui then
-			self.ui:UpdateSyncState(false)
-		end
+		if self.ui then self.ui:UpdateHandshakeState(false) end
+		if self.ui then self.ui:UpdateSyncState(false) end
 
-		if self.wsClient then
-			self.wsClient:disconnect()
-		end
+		if self.wsClient then self.wsClient:disconnect() end
 		self.wsClient = nil
 
 		self.trackedInstances = {}
@@ -1072,15 +922,11 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 		-- Preserve current suppress state for deciding whether to print "Sync stopped"
 		local wasSuppressed = self._suppressAutoConnectLogs == true
 		self._suppressAutoConnectLogs = false
-		if not wasSuppressed then
-			self:infoPrint("Sync stopped")
-		end
+		if not wasSuppressed then self:infoPrint("Sync stopped") end
 	end
 
 	function self:onSettingsScopeChanged(newScope: string)
-		if newScope == self.settingsStore:getScope() then
-			return
-		end
+		if newScope == self.settingsStore:getScope() then return end
 
 		self.settingsStore:setScope(newScope)
 		if self.ui then
@@ -1095,9 +941,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 
 	-- Auto-connect control: run a background task to attempt connects and honor config
 	function self:startAutoConnect()
-		if self._autoConnectThread then
-			return
-		end
+		if self._autoConnectThread then return end
 		self._autoConnectThread = task.spawn(function()
 			local attempts = 0
 			self:infoPrint("Auto-connect enabled")
@@ -1114,9 +958,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				local handshakeFired = false
 				local conn
 				if self._handshakeBindable then
-					conn = self._handshakeBindable.Event:Connect(function()
-						handshakeFired = true
-					end)
+					conn = self._handshakeBindable.Event:Connect(function() handshakeFired = true end)
 				end
 
 				local waitCount = 0
@@ -1127,14 +969,10 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 				do
 					task.wait(1)
 					waitCount += 1
-					if handshakeFired then
-						break
-					end
+					if handshakeFired then break end
 				end
 
-				if conn then
-					conn:Disconnect()
-				end
+				if conn then conn:Disconnect() end
 
 				if self.handshakeComplete then
 					attempts = 0
@@ -1155,9 +993,7 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 					-- Wait before next attempt
 					task.wait(safeGetNumber(self.config.RECONNECTION_INTERVAL, 5))
 				end
-				if not self.config.AUTO_CONNECT then
-					break
-				end
+				if not self.config.AUTO_CONNECT then break end
 				-- minor yield to avoid tight loop
 				task.wait(0.1)
 			end
@@ -1168,16 +1004,10 @@ function SyncSession.new(plugin: Plugin, settingsStore: SettingsStore.SettingsSt
 	end
 
 	function self:stopAutoConnect()
-		if not self._autoConnectThread then
-			return
-		end
-		local ok, err = pcall(function()
-			task.cancel(self._autoConnectThread)
-		end)
+		if not self._autoConnectThread then return end
+		local ok, err = pcall(function() task.cancel(self._autoConnectThread) end)
 		self._autoConnectThread = nil
-		if not ok then
-			warn("AutoConnect: failed to cancel thread:", err)
-		end
+		if not ok then warn("AutoConnect: failed to cancel thread:", err) end
 	end
 
 	return self :: SyncSession

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SyncSession.luau
@@ -17,6 +17,7 @@ local ScriptEditorService = game:GetService("ScriptEditorService")
 -- Modules
 local AzulService = require("./AzulService")
 local Enums = require("./Enums")
+local Logger = require("./Logger")
 local SettingsStore = require("./SettingsStore")
 local WebSocketClient = require("./WebSocketClient")
 
@@ -90,10 +91,7 @@ function SyncSession:debugPrint(...)
 	print(`[🐛 Azul::{script}]:`, ...)
 end
 
-function SyncSession:infoPrint(...)
-	if self.config.SILENT_MODE then return end
-	print(`[Azul]: `, ...)
-end
+function SyncSession:infoPrint(...) Logger.info("[Azul]:", ...) end
 
 function SyncSession:rebuildServiceSet() AzulService.rebuildServiceSet(self.serviceSet) end
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/UI.luau
@@ -60,10 +60,6 @@ type AzulUI = {
 UI.logo = "rbxassetid://134336592598474"
 UI.syncedLogo = "rbxassetid://103599828888609"
 
-local function infoPrint(...)
-	print(`[Azul]: `, ...)
-end
-
 local function debugPrint(...)
 	if not Config.DEBUG_MODE then return end
 	print(`[🐛 Azul::{script}]: `, ...)
@@ -236,7 +232,6 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 	end)
 	mainSection:AddChild(syncButton:GetFrame())
 	self.syncButton = syncButton
-
 
 	-- Silent Mode checkbox
 	local silentModeCheckbox = LabeledCheckbox.new("silentMode", "Silent Mode", Config.SILENT_MODE, false)
@@ -475,9 +470,7 @@ return {}
 		`{getBuilderIcon("arrow-spin-clockwise", true)} Reload Sourcemap`,
 		false
 	)
-	reloadSourcemapButton:SetClickedFunction(function()
-		self.callbacks.onSourcemapReload()
-	end)
+	reloadSourcemapButton:SetClickedFunction(function() self.callbacks.onSourcemapReload() end)
 	reloadSourcemapButton:SetSize(UDim2.fromScale(1, 0.06))
 
 	local reloadSourcemapPadding = Instance.new("UIPadding")
@@ -494,16 +487,12 @@ return {}
 	settingsSection:AddChild(createInfoLabel(`Azul Plugin: v{AzulService.VERSION}`))
 
 	-- Connect button click handler
-	self.connectButton.Click:Connect(function()
-		azulWidget.Enabled = not azulWidget.Enabled
-	end)
+	self.connectButton.Click:Connect(function() azulWidget.Enabled = not azulWidget.Enabled end)
 
 	return (self :: any) :: AzulUI
 end
 
-function UI:GetSyncState()
-	return self.isSyncEnabled
-end
+function UI:GetSyncState() return self.isSyncEnabled end
 
 function UI:UpdateSyncState(enabled: boolean)
 	self.isSyncEnabled = enabled
@@ -519,9 +508,7 @@ function UI:UpdateSyncState(enabled: boolean)
 	end
 end
 
-function UI:SetSettingsScope(scope)
-	self.settingsScope = scope
-end
+function UI:SetSettingsScope(scope) self.settingsScope = scope end
 
 function UI:UpdateConfig()
 	self = self :: AzulUI

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,28 +315,23 @@ export class SyncDaemon {
         sibling => sibling.parent?.guid === node.parentGuid && sibling.name === node.name,
       );
 
-      if (sameNameScriptNodes.length !== 0) {
-        // SN meaning same name
-        const scriptToRename = sameNameScriptNodes.at(-1);
-        if (scriptToRename) {
-          const oldFilePaths = scriptToRename.path;
+      for (const scriptToRename of sameNameScriptNodes) {
+        if (scriptToRename.path.length !== 0) {
           const newFilePath = this.fileWriter.getFilePath(scriptToRename);
 
-          if (oldFilePaths.length !== 0) {
-            // Write new one path
-            this.fileWatcher.suppressNextChange(newFilePath, scriptToRename.source);
-            this.fileWriter.writeScript(scriptToRename);
+          // Write new path
+          this.fileWatcher.suppressNextChange(newFilePath, scriptToRename.source);
+          this.fileWriter.writeScript(scriptToRename);
 
-            // Upsert the subtree into the sourcemap
-            this.sourcemapGenerator.upsertSubtree(
-              scriptToRename,
-              this.tree.getAllNodes(),
-              this.fileWriter.getAllMappings(),
-              config.sourcemapPath,
-              oldFilePaths,
-              false,
-            );
-          }
+          // Upsert the subtree into the sourcemap
+          this.sourcemapGenerator.upsertSubtree(
+            scriptToRename,
+            this.tree.getAllNodes(),
+            this.fileWriter.getAllMappings(),
+            config.sourcemapPath,
+            undefined,
+            false,
+          );
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,6 +309,36 @@ export class SyncDaemon {
       }
     }
 
+    if (node.parentGuid) {
+      const siblingScriptNodes = this.tree.getDescendantScripts(node.parentGuid);
+      const sameNameScriptNodes = siblingScriptNodes.filter(sibling => sibling.name === node.name);
+
+      if (sameNameScriptNodes.length !== 0) {
+        // SN meaning same name
+        const scriptToRename = sameNameScriptNodes.at(-1);
+        if (scriptToRename) {
+          const oldFilePaths = scriptToRename.path;
+          const newFilePath = this.fileWriter.getFilePath(scriptToRename);
+
+          if (oldFilePaths.length !== 0) {
+            // Write new one path
+            this.fileWatcher.suppressNextChange(newFilePath, scriptToRename.source);
+            this.fileWriter.writeScript(scriptToRename);
+
+            // Upsert the subtree into the sourcemap
+            this.sourcemapGenerator.upsertSubtree(
+              scriptToRename,
+              this.tree.getAllNodes(),
+              this.fileWriter.getAllMappings(),
+              config.sourcemapPath,
+              oldFilePaths,
+              false,
+            );
+          }
+        }
+      }
+    }
+
     this.fileWriter.cleanupEmptyDirectories();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,7 +311,9 @@ export class SyncDaemon {
 
     if (node.parentGuid) {
       const siblingScriptNodes = this.tree.getDescendantScripts(node.parentGuid);
-      const sameNameScriptNodes = siblingScriptNodes.filter(sibling => sibling.name === node.name);
+      const sameNameScriptNodes = siblingScriptNodes.filter(
+        sibling => sibling.parent?.guid === node.parentGuid && sibling.name === node.name,
+      );
 
       if (sameNameScriptNodes.length !== 0) {
         // SN meaning same name


### PR DESCRIPTION
## Daemon
* Remove instances moved to excluded parents (#50)
* Rename GUID-suffixed scripts when name conflicts are resolved (#52)

## Plugin
* Setup per-instance listeners after successful handshake instead of every connection attempt
  * Fixes lag spikes when leaving AutoConnect on.
* Serializer: Serialize script-accessible properties that are still marked as `Serialized = false` (fixes #54)
  * Fixes an edge case where [`SerializationService`](https://create.roblox.com/docs/reference/engine/classes/SerializationService) marks the `Part0` & `Part1` of `WeldConstraint`s as `Serialized = false`, preventing `azul pack` from serializing it properly. This fix takes a preventive approach and opts to serialize every property that is script-accessible.
* `--destructive` builds: Skip `Terrain` instance instead of attempting to `Destroy`. (closes #53)
* Replace all Info-level `print`s with `LogService:Info` (blue output)