### PR TITLE
feat(plugin): add auto-open toggle to plugin UI

### DIFF
--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/App/UI.luau
@@ -68,6 +68,7 @@ type AzulUI = {
 	autoConnect: fusion.Value<boolean>,
 	debugMode: fusion.Value<boolean>,
 	silentMode: fusion.Value<boolean>,
+	autoOpenModal: fusion.Value<boolean>,
 	settingsScopeValue: fusion.Value<string>,
 	listTypeValue: fusion.Value<string>,
 
@@ -230,12 +231,13 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 	self.isSyncEnabled = false
 
 	self.icon = Value(self.LOGO)
-	self.isOpen = Value(true)
+	self.isOpen = Value(Config.AUTO_OPEN_MODAL and true or false)
 	self.syncEnabled = Value(false)
 	self.handshakeComplete = Value(false)
 	self.autoConnect = Value(Config.AUTO_CONNECT)
 	self.debugMode = Value(Config.DEBUG_MODE)
 	self.silentMode = Value(Config.SILENT_MODE)
+	self.autoOpenModal = Value(Config.AUTO_OPEN_MODAL)
 	self.settingsScopeValue = Value(settingsScope == Enums.scope.GLOBAL and "Global" or "Project")
 	self.listTypeValue = Value(Config.LIST_TYPE == Enums.listType.WHITELIST and "Whitelist" or "Blacklist")
 
@@ -267,7 +269,7 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 		MinimumSize = Vector2.new(300, 300),
 		FloatingSize = Vector2.new(345, 640),
 		InitialDockTo = Enum.InitialDockState.Float,
-		InitialEnabled = true,
+		InitialEnabled = Config.AUTO_OPEN_MODAL and true or false,
 		Enabled = self.isOpen,
 		[Children] = {
 			Container({
@@ -346,6 +348,11 @@ function UI.new(plugin, callbacks, settingsScope, helpers): AzulUI
 									end
 								end),
 								infoText("Enables verbose logging in the output console."),
+								labeledToggle("Auto Open Modal", self.autoOpenModal, function(newValue)
+									Config.AUTO_OPEN_MODAL = newValue
+									self.callbacks.onConfigChanged("AUTO_OPEN_MODAL", newValue)
+								end),
+								infoText("Opens the plugin modal when Studio first launches."),
 								Text({
 									Text = "Settings Scope",
 									TextSize = Theme.TextSize.Small,
@@ -533,6 +540,7 @@ function UI:UpdateConfig()
 	self.autoConnect:set(Config.AUTO_CONNECT)
 	self.debugMode:set(Config.DEBUG_MODE)
 	self.silentMode:set(Config.SILENT_MODE)
+	self.autoOpenModal:set(Config.AUTO_OPEN_MODAL)
 	self.settingsScopeValue:set(if self.settingsScope == Enums.scope.GLOBAL then "Global" else "Project")
 	self.listTypeValue:set(if Config.LIST_TYPE == Enums.listType.WHITELIST then "Whitelist" else "Blacklist")
 

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
@@ -7,7 +7,7 @@ configTable = {
 	MAX_HANDSHAKES = 5, --// Maximum handshake attempts per connection
 	MAX_RECONNECTIONS = -1, --// Maximum total reconnection attempts before giving up (-1 for infinite)
 	RECONNECTION_INTERVAL = 5,
-	
+
 	HEARTBEAT_INTERVAL = 30,
 	BATCH_IDLE_WINDOW = 0.1,
 	SCRIPT_CHANGE_DEBOUNCE = 0.35,
@@ -33,6 +33,7 @@ configTable = {
 	AUTO_CONNECT = false,
 	DEBUG_MODE = false,
 	SILENT_MODE = false,
+	AUTO_OPEN_MODAL = false,
 }
 
 return configTable

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/Config.luau
@@ -33,7 +33,7 @@ configTable = {
 	AUTO_CONNECT = false,
 	DEBUG_MODE = false,
 	SILENT_MODE = false,
-	AUTO_OPEN_MODAL = false,
+	AUTO_OPEN_MODAL = true,
 }
 
 return configTable

--- a/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SettingsStore.luau
+++ b/plugin/sync/ReplicatedFirst/AzulCompanionPlugin/SettingsStore.luau
@@ -113,6 +113,7 @@ function SettingsStore:saveSettings()
 	if type(globalScoped) ~= "table" then globalScoped = {} end
 	globalScoped.DEBUG_MODE = self.config.DEBUG_MODE
 	globalScoped.SILENT_MODE = self.config.SILENT_MODE
+	globalScoped.AUTO_OPEN_MODAL = self.config.AUTO_OPEN_MODAL
 	allSettings[self.scopeEnum.GLOBAL] = globalScoped
 
 	allSettings[scopeKey] = scopedCopy
@@ -150,9 +151,10 @@ function SettingsStore:loadSettings()
 		if value ~= nil then self.config[key] = value end
 	end
 
-	-- DEBUG_MODE and SILENT_MODE always come from global.
+	-- DEBUG_MODE, SILENT_MODE and AUTO_OPEN_MODAL always come from global.
 	if globalScoped.DEBUG_MODE ~= nil then self.config.DEBUG_MODE = globalScoped.DEBUG_MODE end
 	if globalScoped.SILENT_MODE ~= nil then self.config.SILENT_MODE = globalScoped.SILENT_MODE end
+	if globalScoped.AUTO_OPEN_MODAL ~= nil then self.config.AUTO_OPEN_MODAL = globalScoped.AUTO_OPEN_MODAL end
 end
 
 function SettingsStore:getScope(): string


### PR DESCRIPTION
this PR adds a new global setting to the Azul plugin, which lets you toggle whether the plugin's window should open automatically when a new Studio instance opens.

<img width="477" height="506" alt="image" src="https://github.com/user-attachments/assets/f86813b6-0ed4-499f-b30b-9072ee9895a3" />

(the default is false, but this could be changed to true for backwards compatibility)