### PR TITLE
feat(cli): Inquirer rework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@inquirer/prompts": "^8.7.0",
         "chokidar": "^5.0.0",
         "ws": "^8.16.0"
       },
@@ -22,7 +23,7 @@
         "typescript": "^7.0.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -441,11 +442,339 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
+      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
+      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
+      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/external-editor": "^3.0.4",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
+      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
+      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
+      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
+      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
+      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
+      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.3",
+        "@inquirer/confirm": "^6.3.0",
+        "@inquirer/editor": "^5.3.1",
+        "@inquirer/expand": "^5.1.3",
+        "@inquirer/input": "^5.1.4",
+        "@inquirer/number": "^4.2.1",
+        "@inquirer/password": "^5.2.0",
+        "@inquirer/rawlist": "^5.3.3",
+        "@inquirer/search": "^4.3.1",
+        "@inquirer/select": "^5.2.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
+      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
+      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
+      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -799,6 +1128,12 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -812,6 +1147,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/esbuild": {
@@ -855,6 +1199,30 @@
         "@esbuild/win32-x64": "0.27.1"
       }
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -881,6 +1249,31 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
@@ -901,6 +1294,24 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tsx": {
@@ -961,12 +1372,13 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/Ransomwave/azul"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.7.0",
     "chokidar": "^5.0.0",
     "ws": "^8.16.0"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,10 +133,7 @@ if (
     `Looks like you're trying to run Azul from within a '${config.syncDir}' directory. Running Azul here will create a directory like "/${config.syncDir}/${config.syncDir}/", which may be unintended.`,
   );
 
-  const continueFromSyncDir = await prompt.getYesNoInput(
-    "Continue? (Y/N)",
-    "Please answer Y (yes) or N (no). Are you sure? (Y/N)",
-  );
+  const continueFromSyncDir = await prompt.getYesNoInput("Continue?");
 
   if (!continueFromSyncDir) {
     log.info("Exiting. Please run azul from your project root.");
@@ -175,14 +172,15 @@ if (parsedArgs.command === "build") {
     const sourcemapExists = fs.existsSync(config.sourcemapPath);
     if (sourcemapExists) {
       const useFull = await prompt.getYesNoInput(
-        `Build directly from ${config.sourcemapPath} (includes non-script instances)? (Y/N)`,
+        `Build directly from ${config.sourcemapPath} (includes non-script instances)?`,
       );
       if (useFull) {
         useSourcemapAsSource = true;
         applySourcemapProperties = false;
       } else {
         applySourcemapProperties = await prompt.getYesNoInput(
-          `Use packed properties/attributes from ${config.sourcemapPath}? (Y/N)`,
+          `Use packed properties/attributes from ${config.sourcemapPath}?`,
+          true,
         );
       }
     } else {
@@ -197,7 +195,7 @@ if (parsedArgs.command === "build") {
     // This functionality is still possible with the "--destructive" flag if someone really wants it
     if (useSourcemapAsSource || applySourcemapProperties) {
       interactiveDestructive = await prompt.getYesNoInput(
-        "Destructive build (wipe everything in Studio & build from scratch)? (Y/N)",
+        "Destructive build (wipe everything in Studio & build from scratch)?",
       );
     }
   }
@@ -213,10 +211,7 @@ if (parsedArgs.command === "build") {
       );
     }
 
-    const shouldContinue = await prompt.getYesNoInput(
-      "Continue with build? (Y/N)",
-      "Please answer Y (yes) or N (no). Continue with build? (Y/N)",
-    );
+    const shouldContinue = await prompt.getYesNoInput("Continue with build?");
 
     if (!shouldContinue) {
       log.info("Exiting build command...");
@@ -265,14 +260,14 @@ if (parsedArgs.command === "push") {
 
   if (!hasPushSpecificOptions && !parsedArgs.rojo) {
     const useConfig = await prompt.getYesNoInput(
-      "Use place config from Studio (ServerStorage.Azul.Config)? (Y/N)",
+      "Use place config from Studio (ServerStorage.Azul.Config)?",
+      true,
     );
     interactiveUsePlaceConfig = useConfig;
 
     if (!useConfig) {
       interactiveSource =
-        (await prompt.getInput("Source folder to push (e.g., src)?")).trim() ||
-        undefined;
+        (await prompt.getInput("Source folder to push?")).trim() || undefined;
       interactiveDest =
         (
           await prompt.getInput(
@@ -280,7 +275,7 @@ if (parsedArgs.command === "push") {
           )
         ).trim() || undefined;
       interactiveDestructive = await prompt.getYesNoInput(
-        "Destructive push (wipe destination children)? (Y/N)",
+        "Destructive push (wipe destination children)?",
       );
     }
   }
@@ -296,12 +291,13 @@ if (parsedArgs.command === "push") {
     !willUsePlaceConfig
   ) {
     useSourcemapAsSource = await prompt.getYesNoInput(
-      `Build push snapshot directly from ${config.sourcemapPath} (includes non-script descendants and ancestors)? (Y/N)`,
+      `Build push snapshot directly from ${config.sourcemapPath} (includes non-script descendants and ancestors)?`,
     );
     if (useSourcemapAsSource) {
       if (fs.existsSync(config.sourcemapPath)) {
         applySourcemapProperties = await prompt.getYesNoInput(
-          `Apply packed properties/attributes from ${config.sourcemapPath}? (Y/N)`,
+          `Apply packed properties/attributes from ${config.sourcemapPath}?`,
+          true,
         );
       } else {
         useSourcemapAsSource = false;
@@ -327,12 +323,11 @@ if (parsedArgs.command === "push") {
 
   if (parsedArgs.destructive && !parsedArgs.noWarn) {
     log.warn(
-      "CAUTION: Destructive push will wipe destination children before applying snapshot. Proceed? (Y/N)",
+      "CAUTION: Destructive push will wipe destination children before applying snapshot.",
     );
 
     const shouldContinue = await prompt.getYesNoInput(
-      "Continue with destructive push? (Y/N)",
-      "Please answer Y (yes) or N (no). Continue with destructive push? (Y/N)",
+      "Continue with destructive push?",
     );
 
     if (!shouldContinue) {
@@ -471,7 +466,8 @@ async function promptPackInteractive(defaultOutputPath: string): Promise<{
 }> {
   log.info("Interactive mode: configuring 'azul pack'.");
   const scriptsOnly = !(await prompt.getYesNoInput(
-    "Serialize everything? (Y/N)",
+    "Serialize everything?",
+    true,
   ));
 
   if (scriptsOnly) {
@@ -480,11 +476,9 @@ async function promptPackInteractive(defaultOutputPath: string): Promise<{
     );
   }
 
-  const outputInput = await prompt.getInput(
-    `Output sourcemap path? (press Enter for '${defaultOutputPath}')`,
-  );
-  const outputPath =
-    outputInput.trim() === "" ? defaultOutputPath : outputInput.trim();
+  const outputPath = (
+    await prompt.getInput("Output sourcemap path?", defaultOutputPath)
+  ).trim();
 
   return {
     outputPath,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import fs from "node:fs";
 import { spawn } from "node:child_process";
 import { SyncDaemon } from "./index.js"; // or refactor to export the class
@@ -167,26 +167,28 @@ if (parsedArgs.command === "build") {
   let applySourcemapProperties = true;
   let useSourcemapAsSource = parsedArgs.fromSourcemap !== undefined;
   let interactiveDestructive = parsedArgs.destructive;
+  let interactiveSourcemapPath = parsedArgs.fromSourcemap;
 
   if (!hasBuildSpecificOptions) {
-    const sourcemapExists = fs.existsSync(config.sourcemapPath);
-    if (sourcemapExists) {
+    const chosenSourcemap = await promptSourcemapChoice("build");
+    if (chosenSourcemap) {
+      interactiveSourcemapPath = chosenSourcemap;
       const useFull = await prompt.getYesNoInput(
-        `Build directly from ${config.sourcemapPath} (includes non-script instances)?`,
+        `Build directly from ${chosenSourcemap} (includes non-script instances)?`,
       );
       if (useFull) {
         useSourcemapAsSource = true;
         applySourcemapProperties = false;
       } else {
         applySourcemapProperties = await prompt.getYesNoInput(
-          `Use packed properties/attributes from ${config.sourcemapPath}?`,
+          `Use packed properties/attributes from ${chosenSourcemap}?`,
           true,
         );
       }
     } else {
       applySourcemapProperties = false;
       log.info(
-        `No sourcemap found at ${config.sourcemapPath}. Build will recreate instances as scripts/folders.`,
+        "Not using a sourcemap. Build will recreate instances as scripts/folders.",
       );
     }
 
@@ -225,7 +227,7 @@ if (parsedArgs.command === "build") {
     rojoProjectFile: parsedArgs.rojoProject ?? undefined,
     applySourcemapProperties,
     useSourcemapAsSource,
-    sourcemapPath: parsedArgs.fromSourcemap,
+    sourcemapPath: interactiveSourcemapPath,
     destructive: interactiveDestructive,
   }).run();
 
@@ -257,6 +259,7 @@ if (parsedArgs.command === "push") {
     !parsedArgs.rojo && parsedArgs.fromSourcemap !== undefined;
   let applySourcemapProperties =
     !parsedArgs.rojo && parsedArgs.fromSourcemap === undefined;
+  let interactiveSourcemapPath = parsedArgs.fromSourcemap;
 
   if (!hasPushSpecificOptions && !parsedArgs.rojo) {
     const useConfig = await prompt.getYesNoInput(
@@ -290,22 +293,16 @@ if (parsedArgs.command === "push") {
     parsedArgs.fromSourcemap === undefined &&
     !willUsePlaceConfig
   ) {
-    useSourcemapAsSource = await prompt.getYesNoInput(
-      `Build push snapshot directly from ${config.sourcemapPath} (includes non-script descendants and ancestors)?`,
-    );
-    if (useSourcemapAsSource) {
-      if (fs.existsSync(config.sourcemapPath)) {
-        applySourcemapProperties = await prompt.getYesNoInput(
-          `Apply packed properties/attributes from ${config.sourcemapPath}?`,
-          true,
-        );
-      } else {
-        useSourcemapAsSource = false;
-        applySourcemapProperties = false;
-        throw new Error(
-          `Sourcemap not found at "${config.sourcemapPath}"! Please create one or provide it using the "--from-sourcemap" flag.`,
-        );
-      }
+    const chosenSourcemap = await promptSourcemapChoice("push");
+    if (chosenSourcemap) {
+      interactiveSourcemapPath = chosenSourcemap;
+      useSourcemapAsSource = await prompt.getYesNoInput(
+        `Build push snapshot directly from ${chosenSourcemap} (includes non-script descendants and ancestors)?`,
+      );
+      applySourcemapProperties = await prompt.getYesNoInput(
+        `Apply packed properties/attributes from ${chosenSourcemap}?`,
+        true,
+      );
     } else {
       useSourcemapAsSource = false;
       applySourcemapProperties = false;
@@ -345,7 +342,7 @@ if (parsedArgs.command === "push") {
     rojoProjectFile: parsedArgs.rojoProject ?? undefined,
     applySourcemapProperties,
     useSourcemapAsSource,
-    sourcemapPath: parsedArgs.fromSourcemap,
+    sourcemapPath: interactiveSourcemapPath,
   }).run();
 
   log.info("Push command completed.");
@@ -458,6 +455,62 @@ function openWithDefaultApp(target: string): Promise<void> {
     child.unref();
     resolvePromise();
   });
+}
+
+/**
+ * Finds every "*sourcemap.json" sitting next to the configured sourcemap path,
+ * so projects keeping per-place maps (game.sourcemap.json, ...) can pick one.
+ * Returns paths relative to the cwd, configured path first.
+ */
+function findSourcemaps(): string[] {
+  const configured = resolve(config.sourcemapPath);
+  const dir = dirname(configured);
+
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter(
+      (entry) =>
+        entry.isFile() && entry.name.toLowerCase().endsWith("sourcemap.json"),
+    )
+    .map((entry) => join(dir, entry.name))
+    .sort((a, b) =>
+      a === configured ? -1 : b === configured ? 1 : a.localeCompare(b),
+    )
+    .map((file) => relative(process.cwd(), file) || file);
+}
+
+/**
+ * Asks which sourcemap to use. Only prompts when there's an actual choice to
+ * make; returns null when there is no sourcemap to use, either because none
+ * were found or because the user opted out.
+ */
+async function promptSourcemapChoice(action: string): Promise<string | null> {
+  const found = findSourcemaps();
+
+  if (found.length === 0) {
+    log.info(
+      `No sourcemap found in ${dirname(resolve(config.sourcemapPath))}.`,
+    );
+    return null;
+  }
+
+  if (found.length === 1) {
+    return found[0]!;
+  }
+
+  return prompt.getChoice<string | null>(
+    `Which sourcemap should Azul ${action} from?`,
+    [
+      ...found.map((file) => ({ name: file, value: file as string | null })),
+      { name: "Don't use a sourcemap", value: null },
+    ],
+  );
 }
 
 async function promptPackInteractive(defaultOutputPath: string): Promise<{

--- a/src/push.ts
+++ b/src/push.ts
@@ -65,6 +65,13 @@ export class PushCommand {
   }
 
   public async run(): Promise<void> {
+    if (this.options.destination?.startsWith("game.")) {
+      log.warn(
+        "Do not use 'game.' in the destination; it is implied. Stripping it.",
+      );
+      this.options.destination = this.options.destination.slice(5);
+    }
+
     if (this.options.rojoMode) {
       log.info(
         "Rojo compatibility mode: ignoring place config; destination becomes a prefix.",

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -22,6 +22,11 @@ function timestamp(): string {
   return new Date().toISOString().slice(11, 23);
 }
 
+/** Prompt prefix, so Inquirer questions match the logger's output format. */
+export function promptPrefix(): string {
+  return `${colors.dim}[${timestamp()}]${colors.reset} ${colors.cyan}?${colors.reset}`;
+}
+
 export const log = {
   info(message: string, ...args: any[]): void {
     console.log(
@@ -64,14 +69,6 @@ export const log = {
     }
   },
 
-  userInput(message: string, ...args: any[]): void {
-    console.log(
-      `${colors.dim}[${timestamp()}]${colors.reset} ${colors.cyan}?${
-        colors.reset
-      } ${message}`,
-      ...args,
-    );
-  },
 
   script(path: string, action: "created" | "updated" | "deleted"): void {
     const emoji = action === "created" ? "+" : action === "updated" ? "~" : "−";

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -1,43 +1,44 @@
-import * as ReadLine from "readline";
-import { log } from "./log.js";
+import { confirm, input } from "@inquirer/prompts";
+import { log, promptPrefix } from "./log.js";
 
-function promptLine(): Promise<string> {
-  return new Promise((resolve) => {
-    const rl = ReadLine.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-
-    rl.once("line", (input) => {
-      rl.close();
-      resolve(input);
-    });
-  });
+/**
+ * Inquirer needs raw-mode stdin. Without a TTY (CI, piped input) it aborts with
+ * a bare ExitPromptError, so fail early with something actionable instead.
+ */
+function assertInteractive(): void {
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      "Azul needs an interactive terminal to ask this, but stdin is not a TTY. Pass the relevant flags (--no-warn, --destructive, -s/-d, -o, --scripts-only) to run non-interactively.",
+    );
+  }
 }
 
+/** Ctrl+C inside a prompt throws instead of killing the process. Exit quietly. */
+async function ask<T>(run: () => Promise<T>): Promise<T> {
+  assertInteractive();
+
+  try {
+    return await run();
+  } catch (error) {
+    if (error instanceof Error && error.name === "ExitPromptError") {
+      log.info("Cancelled.");
+      process.exit(130);
+    }
+    throw error;
+  }
+}
+
+// Keeps prompts visually in line with the rest of the logger output.
+const theme = () => ({ prefix: promptPrefix() });
+
 export const prompt = {
-  getInput(message: string): Promise<string> {
-    log.userInput(message);
-    return promptLine();
+  getInput(message: string, defaultValue?: string): Promise<string> {
+    return ask(() => input({ message, default: defaultValue, theme: theme() }));
   },
 
-  async getYesNoInput(
-    message?: string,
-    retryMessage?: string,
-  ): Promise<boolean> {
-    if (message) {
-      log.userInput(message);
-    }
-
-    while (true) {
-      const input = (await promptLine()).trim().toLowerCase();
-      if (input === "y" || input === "yes") {
-        return true;
-      }
-      if (input === "n" || input === "no") {
-        return false;
-      }
-      log.userInput(retryMessage ?? "Please answer Y (yes) or N (no).");
-    }
+  getYesNoInput(message: string, defaultValue = false): Promise<boolean> {
+    return ask(() =>
+      confirm({ message, default: defaultValue, theme: theme() }),
+    );
   },
 };

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -1,4 +1,4 @@
-import { confirm, input } from "@inquirer/prompts";
+import { confirm, input, select } from "@inquirer/prompts";
 import { log, promptPrefix } from "./log.js";
 
 /**
@@ -34,6 +34,13 @@ const theme = () => ({ prefix: promptPrefix() });
 export const prompt = {
   getInput(message: string, defaultValue?: string): Promise<string> {
     return ask(() => input({ message, default: defaultValue, theme: theme() }));
+  },
+
+  getChoice<T>(
+    message: string,
+    choices: ReadonlyArray<{ name: string; value: T }>,
+  ): Promise<T> {
+    return ask(() => select({ message, choices, theme: theme() }));
   },
 
   getYesNoInput(message: string, defaultValue = false): Promise<boolean> {


### PR DESCRIPTION
Remake the interactive CLI interface to be much nicer & friendlier.

* Adds dependency: `@inquirer/prompts`
* Refactor all CLI handling to use Inquirer.
* QoL: Strips `game.` prefix from destination, as it is implicit
* Adds a nice Sourcemap selector when using `azul build` or `azul push`
